### PR TITLE
chore: release-type simple + TOML updater — no julia strategy exists

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,12 +3,19 @@
     "bootstrap-sha": "a15e8bdfb6a8bb4cb96b18e1b5c528282af03db2",
     "packages": {
         ".": {
-            "release-type": "julia",
+            "release-type": "simple",
             "changelog-path": "CHANGELOG.md",
             "include-v-in-tag": true,
             "include-component-in-tag": false,
             "draft": false,
-            "prerelease": false
+            "prerelease": false,
+            "extra-files": [
+                {
+                    "type": "toml",
+                    "path": "Project.toml",
+                    "jsonpath": "$.version"
+                }
+            ]
         }
     }
 }


### PR DESCRIPTION
First ReleasePlease run failed: `Unknown release type: julia` — that strategy was never merged upstream. `simple` + an `extra-files` TOML updater on `Project.toml` `$.version` is the supported equivalent (release-please will also maintain a `version.txt`, which is harmless).

## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/GroupTherapyOrg/SpaceStation.jl", rev="fix-release-type")
julia> using SpaceStation
```
