### PR TITLE
fix: registration notes must say 'changelog'/'breaking' for AutoMerge

### DIFF
--- a/.github/workflows/ReleasePlease.yml
+++ b/.github/workflows/ReleasePlease.yml
@@ -49,6 +49,9 @@ jobs:
         steps:
             # JuliaRegistrator listens for this comment on the release commit.
             # Registration in General is then picked up by AutoMerge (~15-20 min).
+            # The notes MUST contain the word "breaking" or "changelog": General's AutoMerge
+            # treats pre-1.0 minor bumps (and any major bump) as breaking and refuses to
+            # auto-merge unless the release notes acknowledge it (learned on v0.2.0).
             - uses: peter-evans/commit-comment@v3
               with:
                   token: ${{ secrets.PAT_TOKEN || github.token }}
@@ -56,4 +59,6 @@ jobs:
                   body: |
                       @JuliaRegistrator register
 
-                      Release notes: https://github.com/${{ github.repository }}/releases/tag/${{ needs.release-please.outputs.tag_name }}
+                      Release notes:
+
+                      See the changelog for this release (may include breaking changes): https://github.com/${{ github.repository }}/blob/main/CHANGELOG.md


### PR DESCRIPTION
General's AutoMerge blocked v0.2.0's registration: pre-1.0 minor bumps are treated as breaking and the release notes must contain the word "breaking" or "changelog" (the previous comment only had a bare release URL). The register comment now includes the required wording + CHANGELOG link. v0.2.0's registration was already re-triggered manually with compliant notes.

## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/GroupTherapyOrg/SpaceStation.jl", rev="fix-register-notes")
julia> using SpaceStation
```
