### PR TITLE
docs: document the live-concurrency guarantees in the agent stanza

### DIFF
--- a/COLLAB.md
+++ b/COLLAB.md
@@ -186,6 +186,17 @@ Notebooks here may be OPEN in a live lazy-mode SpaceStation server shared with a
   dead/exited worker ("Process exited" / `TerminatedWorkerException`); interrupt/run can't revive one.
 - All cell outputs are also in `<nb.jl>.pluto-cache.toml` (plain TOML; a deletable cache).
 
+**Live-concurrency guarantees** (server-enforced — parallel agents and a human can work at once):
+
+- Concurrent `run` requests are serialized per notebook; the second recomputes staleness after the
+  first finishes, so nothing ever double-executes.
+- Editing a cell WHILE it is running is safe: the edit stays pending/stale (outputs are keyed to the
+  code that actually ran) — `status` afterwards shows it, `run --stale` applies it.
+- A `restart` while another restart is in flight is refused ("already in progress") — poll `status`.
+- One caveat: a human's browser edit saves the whole `.jl`; an agent write landing in that same
+  instant can be overwritten (the server logs a warning when it happens). Running `status` right
+  after your edit confirms the server picked it up.
+
 On Windows or where bash/curl are missing, use the identical `spacestation collab <command> …`.
 ```
 

--- a/src/AgentSurface.jl
+++ b/src/AgentSurface.jl
@@ -150,6 +150,17 @@ and the human sees the staleness in their browser within ~1s. To apply your chan
 - Every cell's output is also mirrored in `<nb.jl>.pluto-cache.toml` (plain TOML; a deletable cache
   you can read without running anything).
 
+**Live-concurrency guarantees** (server-enforced — parallel agents and a human can work at once):
+
+- Concurrent `run` requests are serialized per notebook; the second recomputes staleness after the
+  first finishes, so nothing ever double-executes.
+- Editing a cell WHILE it is running is safe: the edit stays pending/stale (outputs are keyed to the
+  code that actually ran) — `status` afterwards shows it, `run --stale` applies it.
+- A `restart` while another restart is in flight is refused ("already in progress") — poll `status`.
+- One caveat: a human's browser edit saves the whole `.jl`; an agent write landing in that same
+  instant can be overwritten (the server logs a warning when it happens). Running `status` right
+  after your edit confirms the server picked it up.
+
 `pluto-collab` is on your PATH. Inside a SpaceStation terminal the live server is in
 `PLUTOSPACE_PORT` / `PLUTOSPACE_SECRET`, so `pluto-collab` targets it automatically.
 


### PR DESCRIPTION
Tells agents what the v0.2.0 race hardening now guarantees (serialized runs, safe edit-during-run, refused concurrent restarts) and the one remaining caveat (simultaneous browser save vs agent write — last writer wins, server-warned). Updated in both the managed AGENTS.md/CLAUDE.md block and COLLAB.md. Workspaces pick up the new block automatically on next open (idempotent regeneration).

## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/GroupTherapyOrg/SpaceStation.jl", rev="docs-agent-concurrency")
julia> using SpaceStation
```
