### PR TITLE
chore: fix the bundler's CDN-download race that shipped a 0-byte icon

### DIFF
--- a/.github/workflows/Bundle.yml
+++ b/.github/workflows/Bundle.yml
@@ -112,14 +112,20 @@ jobs:
             - name: Check for corrupt files
               working-directory: frontend-dist
               run: |
-                if [[ $(find . -empty) ]]; then
+                empties=$(find . -empty)
+                if [[ -n $empties ]]; then
+                    echo "::error::Empty files in the bundle:"
+                    echo "$empties"
                     exit 1
                 fi
 
             - name: Check for corrupt files - offline
               working-directory: frontend-dist-offline
               run: |
-                if [[ $(find . -empty) ]]; then
+                empties=$(find . -empty)
+                if [[ -n $empties ]]; then
+                    echo "::error::Empty files in the offline bundle:"
+                    echo "$empties"
                     exit 1
                 fi
 

--- a/frontend-bundler/parcel-resolver-like-a-browser/https-resolver.js
+++ b/frontend-bundler/parcel-resolver-like-a-browser/https-resolver.js
@@ -9,6 +9,12 @@ let DONT_INCLUDE = { isExcluded: true }
 
 const fileExists = async (path) => !!(await fs.stat(path).catch((e) => false))
 
+// One in-flight download per cache path. Concurrent resolves of the SAME uncached URL (e.g.
+// copy-outline.svg, referenced from three stylesheets) used to race: each saw "no file" and
+// parallel writeFile calls to one path let parcel read a half-written (even empty) asset — the
+// release branch shipped a 0-byte icon. See the download block below.
+const inflight_downloads = new Map()
+
 async function keep_trying(fn, max_tries = 10) {
     try {
         return await fn()
@@ -90,34 +96,47 @@ module.exports = new Resolver({
             let fullpath = path.join(my_temp_cave, url_to_path)
             let folder = path.dirname(fullpath)
 
-            if (!(await fileExists(fullpath))) {
-                // Modest throttle on actual CDN downloads (cache misses only) to avoid hammering
-                // esm.sh/jsdelivr. The original slept 10s on EVERY resolve (even local files),
-                // which made the build crawl; cached deps and local files are now instant.
-                await new Promise((resolve) => setTimeout(resolve, 1000))
-                await keep_trying(async () => {
-                    let response = await fetch(specifier)
-                    if (response.status !== 200) {
-                        throw new Error(`${specifier} returned ${response.status}`)
-                    }
-                    // Can't directly use the value from the request, as parcel really wants a string,
-                    // and converting binary assets into strings and then passing them doesn't work 🤷‍♀️.
-                    let buffer = await response.arrayBuffer()
+            // An empty cached file is a poisoned cache entry (a crashed or torn earlier write) —
+            // treat it as a miss and re-download.
+            const cached_size = await fs.stat(fullpath).then((s) => s.size).catch(() => -1)
+            if (cached_size <= 0) {
+                let pending = inflight_downloads.get(fullpath)
+                if (pending == null) {
+                    pending = (async () => {
+                        // Modest throttle on actual CDN downloads (cache misses only) to avoid hammering
+                        // esm.sh/jsdelivr. The original slept 10s on EVERY resolve (even local files),
+                        // which made the build crawl; cached deps and local files are now instant.
+                        await new Promise((resolve) => setTimeout(resolve, 1000))
+                        await keep_trying(async () => {
+                            let response = await fetch(specifier)
+                            if (response.status !== 200) {
+                                throw new Error(`${specifier} returned ${response.status}`)
+                            }
+                            // Can't directly use the value from the request, as parcel really wants a string,
+                            // and converting binary assets into strings and then passing them doesn't work 🤷‍♀️.
+                            let buffer = await response.arrayBuffer()
 
-                    const response_length = buffer.byteLength
+                            const response_length = buffer.byteLength
 
-                    if (response_length === 0) {
-                        throw new Error(`${specifier} returned an empty reponse.`)
-                    }
+                            if (response_length === 0) {
+                                throw new Error(`${specifier} returned an empty reponse.`)
+                            }
 
-                    await mkdirp(folder)
-                    const write_result = await fs.writeFile(fullpath, Buffer.from(buffer))
-
-                    // Verify that the file was written correctly:
-                    if (write_result !== undefined || (await fs.readFile(fullpath)).length !== response_length) {
-                        throw new Error(`Failed to write file ${fullpath}`)
-                    }
-                })
+                            await mkdirp(folder)
+                            // Unique temp file + rename: the cache entry is either absent or
+                            // complete, never half-written — even with concurrent builders.
+                            const tmp = `${fullpath}.${process.pid}.${Math.random().toString(36).slice(2)}.tmp`
+                            await fs.writeFile(tmp, Buffer.from(buffer))
+                            if ((await fs.readFile(tmp)).length !== response_length) {
+                                await fs.rm(tmp, { force: true })
+                                throw new Error(`Failed to write file ${fullpath}`)
+                            }
+                            await fs.rename(tmp, fullpath)
+                        })
+                    })().finally(() => inflight_downloads.delete(fullpath))
+                    inflight_downloads.set(fullpath, pending)
+                }
+                await pending
             }
 
             return { filePath: fullpath }


### PR DESCRIPTION
**Why Bundle Web Assets broke on the v0.2.2 release commit**: upstream's CellOutput.js change made `copy-outline.svg` freshly needed; it's referenced from three stylesheets, and on a cold CI cache the custom resolver ran three concurrent downloads racing parallel `writeFile` calls onto one cache path — Parcel read the file mid-write and emitted a 0-byte icon, tripping the corrupt-files check. Locally it built fine (no race landed).

Fix: per-path in-flight download dedup + temp-file-and-rename writes + empty-cache-entry-counts-as-miss. The CI check now also prints *which* files are empty. Verified with a cold-cache local build (0 empty files, icon = 457 bytes).

**No release needed**: `frontend-dist` never ships in the registered package — this only feeds the `release` branch bundle. Committed as `chore:` so release-please stays quiet.

## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/GroupTherapyOrg/SpaceStation.jl", rev="fix-bundler-empty-asset")
julia> using SpaceStation
```
