### PR TITLE
fix: collab run reported "ok" when Safe Preview blocked execution entirely

### DIFF
--- a/src/webserver/CollabAPI.jl
+++ b/src/webserver/CollabAPI.jl
@@ -468,6 +468,18 @@ function register_collab_api!(router, session::ServerSession)
             cells = expand_stale_ancestors(notebook, cells)
         end
 
+        # Honesty check. When code execution is off — Safe Preview (waiting_for_permission: how the
+        # workspace hub opens notebooks until a human clicks "Run notebook code") or a dead worker
+        # (no_process) — update_save_run! silently skips execution, and this endpoint used to count
+        # 0 errored cells and report "RESULT: ok (N cells ran)", exit 0. An unattended agent must
+        # get a hard failure it can act on instead.
+        if !isempty(cells) && !will_run_code(notebook)
+            hint = notebook.process_status == ProcessStatus.waiting_for_permission ?
+                "the notebook is in Safe Preview — a human must grant execution in the browser (\"Run notebook code\"), or the notebook must be opened with execution allowed" :
+                "the worker process is not running — recover it with `restart`"
+            return _api_error(409, "cannot run: code execution is disabled for this notebook (process: $(notebook.process_status)); $hint", fmt_text)
+        end
+
         if !isempty(cells)
             # blocking: the same path as a browser run request, behind the same execution token
             update_save_run!(session, notebook, cells; run_async=false, save=true, auto_solve_multiple_defs=true)


### PR DESCRIPTION
The `run` endpoint's exit-code lie flagged during the SSH investigation: with execution disabled (Safe Preview / dead worker), `update_save_run!` silently skips running and the endpoint still reported `RESULT: ok (N cells ran)` with exit 0 — an unattended agent believed its cells executed.

Now: **409** before running, naming the process state and the remedy (`waiting_for_permission` → grant execution in the browser or reopen with execution allowed; `no_process` → `restart`). Both CLIs turn it into a non-zero exit.

Verified live both ways (Safe Preview → 409/exit 2; granted → runs/exit 0) + `test/collab_cli.sh` 13/13. Releasing as **v0.2.3**.

## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/GroupTherapyOrg/SpaceStation.jl", rev="fix-run-safe-preview")
julia> using SpaceStation
```
