### PR TITLE
Fix terminal paste duplication and permission prompts

### DIFF
--- a/.github/workflows/FrontendTest.yml
+++ b/.github/workflows/FrontendTest.yml
@@ -53,6 +53,7 @@ jobs:
                   options = SpaceStation.Configuration.from_flat_kwargs(;
                     port=parse(Int, ENV["PLUTO_PORT"]),
                     require_secret_for_access=false,
+                    workspace=ENV["GITHUB_WORKSPACE"],
                     # The upstream E2E suite exercises classic autorun Pluto (open runs the
                     # notebook, Safe Preview acceptance runs code). Under the lazy default those
                     # opens only mark cells stale ("Code not executed in Safe preview" outputs).

--- a/frontend/land.js
+++ b/frontend/land.js
@@ -650,8 +650,8 @@ const TerminalView = ({ tid, cwd, visible }) => {
 
             // Copy: Cmd/Ctrl+C copies when there is a selection; otherwise it falls through to the shell
             // as SIGINT. Text paste is deliberately NOT handled here: xterm already consumes the browser's
-            // native `paste` event. Calling term.paste() from Cmd+V as well made Safari deliver every paste
-            // twice — once from this keydown path and once from its native paste event.
+            // native `paste` event. Calling the privileged Clipboard API from Cmd+V as well caused
+            // browser permission prompts and could deliver text twice through the two competing paths.
             term.attachCustomKeyEventHandler((e) => {
                 if (e.type !== "keydown") return true
                 if ((e.metaKey || e.ctrlKey) && (e.key === "c" || e.key === "C") && term.hasSelection()) {
@@ -664,7 +664,7 @@ const TerminalView = ({ tid, cwd, visible }) => {
             // Images cannot go through xterm's text-only paste. Intercept ONLY a native paste carrying
             // an image; ordinary text is left untouched for xterm to process exactly once. Using the
             // ClipboardEvent payload also works without navigator.clipboard permissions and preserves
-            // the browser's user-gesture semantics in Safari.
+            // the browser's native user-gesture semantics.
             const handle_image_paste = async (/** @type {ClipboardEvent} */ e) => {
                 const image_item = Array.from(e.clipboardData?.items ?? []).find((item) => item.type?.startsWith("image/"))
                 const image_file = image_item?.getAsFile() ?? Array.from(e.clipboardData?.files ?? []).find((file) => file.type?.startsWith("image/"))

--- a/frontend/land.js
+++ b/frontend/land.js
@@ -579,6 +579,7 @@ const TerminalView = ({ tid, cwd, visible }) => {
     const socket_ref = useRef(/** @type {WebSocket?} */ (null))
     const term_ref = useRef(/** @type {any} */ (null))
     const ro_ref = useRef(/** @type {ResizeObserver?} */ (null))
+    const paste_cleanup_ref = useRef(/** @type {(() => void)?} */ (null))
 
     // Fit ONLY when the host is genuinely on-screen at a real size, and debounced so a panel that
     // is animating open settles before we measure. Fitting a hidden tab (display:none → 0px) makes
@@ -647,53 +648,43 @@ const TerminalView = ({ tid, cwd, visible }) => {
             // Assigned when the websocket opens (below); the paste handler needs it, so it lives out here.
             let socket = null
 
-            // Paste from the clipboard. An image can't go through xterm's text-only paste — the bytes have
-            // to reach wherever the shell runs (local, or the remote over SSH). So read the clipboard
-            // richly: if it holds an image, base64 it and send a "2:<ext>:<base64>" frame — the server
-            // drops it in a temp file and types the path, so any CLI agent in the shell can open it.
-            // Otherwise paste text, exactly as before. Falls back to readText() if read() is unavailable.
-            const paste_from_clipboard = async () => {
-                try {
-                    if (navigator.clipboard?.read) {
-                        const items = await navigator.clipboard.read()
-                        for (const item of items) {
-                            const image_type = item.types.find((ty) => ty.startsWith("image/"))
-                            if (image_type == null) continue
-                            const bytes = new Uint8Array(await (await item.getType(image_type)).arrayBuffer())
-                            let bin = ""
-                            for (let i = 0; i < bytes.length; i += 0x8000) {
-                                bin += String.fromCharCode.apply(null, bytes.subarray(i, i + 0x8000))
-                            }
-                            const ext = image_type.split("/")[1] || "png"
-                            if (socket?.readyState === WebSocket.OPEN) socket.send(`2:${ext}:${btoa(bin)}`)
-                            return
-                        }
-                    }
-                } catch {
-                    // read() can be unavailable or blocked (permissions/focus) — fall through to text
-                }
-                try {
-                    const text = await navigator.clipboard?.readText()
-                    if (text) term.paste(text)
-                } catch {}
-            }
-
-            // Copy/paste: Cmd/Ctrl+C copies when there is a selection (otherwise it falls through to the
-            // shell as SIGINT); Cmd+V — and Ctrl+Shift+V — paste from the clipboard (text or image). (xterm
-            // already forwards a native browser paste to the shell; this adds the explicit shortcuts, the
-            // selection-aware copy that xterm does not do on its own, and image paste.)
+            // Copy: Cmd/Ctrl+C copies when there is a selection; otherwise it falls through to the shell
+            // as SIGINT. Text paste is deliberately NOT handled here: xterm already consumes the browser's
+            // native `paste` event. Calling term.paste() from Cmd+V as well made Safari deliver every paste
+            // twice — once from this keydown path and once from its native paste event.
             term.attachCustomKeyEventHandler((e) => {
                 if (e.type !== "keydown") return true
                 if ((e.metaKey || e.ctrlKey) && (e.key === "c" || e.key === "C") && term.hasSelection()) {
                     navigator.clipboard?.writeText(term.getSelection()).catch(() => {})
                     return false
                 }
-                if ((e.metaKey && e.key === "v") || (e.ctrlKey && e.shiftKey && (e.key === "v" || e.key === "V"))) {
-                    paste_from_clipboard()
-                    return false
-                }
                 return true
             })
+
+            // Images cannot go through xterm's text-only paste. Intercept ONLY a native paste carrying
+            // an image; ordinary text is left untouched for xterm to process exactly once. Using the
+            // ClipboardEvent payload also works without navigator.clipboard permissions and preserves
+            // the browser's user-gesture semantics in Safari.
+            const handle_image_paste = async (/** @type {ClipboardEvent} */ e) => {
+                const image_item = Array.from(e.clipboardData?.items ?? []).find((item) => item.type?.startsWith("image/"))
+                const image_file = image_item?.getAsFile() ?? Array.from(e.clipboardData?.files ?? []).find((file) => file.type?.startsWith("image/"))
+                if (image_file == null) return
+                e.preventDefault()
+                e.stopPropagation()
+                try {
+                    const bytes = new Uint8Array(await image_file.arrayBuffer())
+                    let bin = ""
+                    for (let i = 0; i < bytes.length; i += 0x8000) {
+                        bin += String.fromCharCode.apply(null, bytes.subarray(i, i + 0x8000))
+                    }
+                    const ext = image_file.type.split("/")[1] || "png"
+                    if (socket?.readyState === WebSocket.OPEN) socket.send(`2:${ext}:${btoa(bin)}`)
+                } catch {}
+            }
+            // Capture before xterm's textarea handler: image clipboards can also expose a text
+            // representation, which xterm must not paste in addition to the uploaded image path.
+            term.element?.addEventListener("paste", handle_image_paste, { capture: true })
+            paste_cleanup_ref.current = () => term.element?.removeEventListener("paste", handle_image_paste, { capture: true })
 
             // Measure after the webfont is ready, so the cell size (hence the column count) is correct.
             try {
@@ -770,6 +761,8 @@ const TerminalView = ({ tid, cwd, visible }) => {
     useEffect(() => {
         return () => {
             clearTimeout(refit_timer.current)
+            paste_cleanup_ref.current?.()
+            paste_cleanup_ref.current = null
             try {
                 ro_ref.current?.disconnect()
             } catch {}

--- a/test/frontend/__tests__/terminal_paste.js
+++ b/test/frontend/__tests__/terminal_paste.js
@@ -30,14 +30,15 @@ describe("SpaceStation terminal paste", () => {
         browser = null
     })
 
-    it("handles Safari's keydown plus native paste as one text paste", async () => {
+    it("uses native text paste once without requesting clipboard-read permission", async () => {
         sentinel = path.join(os.tmpdir(), `spacestation-terminal-paste-${process.pid}-${Date.now()}`)
         const command = `printf X >> '${sentinel}'`
         page = await createPage(browser)
 
         // The old handler explicitly read the clipboard on Cmd+V while xterm also handled the
         // browser's native paste event. Mocking the Clipboard API and delivering both events makes
-        // Safari's double-delivery deterministic in Chromium: old code writes XX, fixed code X.
+        // the competing keydown + native-paste paths deterministic: old code writes XX and invokes
+        // the permission-gated Clipboard API, while fixed code writes X without reading the clipboard.
         await page.evaluateOnNewDocument((text) => {
             window.__clipboardReadCalls = 0
             Object.defineProperty(navigator, "clipboard", {

--- a/test/frontend/__tests__/terminal_paste.js
+++ b/test/frontend/__tests__/terminal_paste.js
@@ -1,0 +1,83 @@
+import fs from "fs"
+import os from "os"
+import path from "path"
+import puppeteer from "puppeteer"
+import { createPage } from "../helpers/common"
+import { getPlutoUrl } from "../helpers/pluto"
+
+describe("SpaceStation terminal paste", () => {
+    /** @type {import("puppeteer").Browser} */
+    let browser = null
+    /** @type {import("puppeteer").Page} */
+    let page = null
+    let sentinel = null
+
+    beforeAll(async () => {
+        browser = await puppeteer.launch({
+            headless: process.env.HEADLESS !== "false" ? "new" : false,
+            args: ["--no-sandbox", "--disable-setuid-sandbox", "--disable-dev-shm-usage"],
+        })
+    })
+
+    afterEach(async () => {
+        await page?.close()
+        page = null
+        if (sentinel != null) fs.rmSync(sentinel, { force: true })
+    })
+
+    afterAll(async () => {
+        await browser?.close()
+        browser = null
+    })
+
+    it("handles Safari's keydown plus native paste as one text paste", async () => {
+        sentinel = path.join(os.tmpdir(), `spacestation-terminal-paste-${process.pid}-${Date.now()}`)
+        const command = `printf X >> '${sentinel}'`
+        page = await createPage(browser)
+
+        // The old handler explicitly read the clipboard on Cmd+V while xterm also handled the
+        // browser's native paste event. Mocking the Clipboard API and delivering both events makes
+        // Safari's double-delivery deterministic in Chromium: old code writes XX, fixed code X.
+        await page.evaluateOnNewDocument((text) => {
+            Object.defineProperty(navigator, "clipboard", {
+                configurable: true,
+                value: {
+                    read: async () => {
+                        throw new Error("force the legacy readText fallback")
+                    },
+                    readText: async () => text,
+                    writeText: async () => {},
+                },
+            })
+        }, command)
+
+        await page.goto(getPlutoUrl(), { waitUntil: "domcontentloaded" })
+        await page.waitForSelector("button.terminal-toggle", { visible: true })
+        await page.click("button.terminal-toggle")
+        await page.waitForSelector(".terminal-host .xterm-helper-textarea", { visible: true, timeout: 30000 })
+
+        await page.evaluate((text) => {
+            const textarea = document.querySelector(".terminal-host .xterm-helper-textarea")
+            textarea.focus()
+            textarea.dispatchEvent(new KeyboardEvent("keydown", { key: "v", metaKey: true, bubbles: true, cancelable: true }))
+            const clipboardData = new DataTransfer()
+            clipboardData.setData("text/plain", text)
+            textarea.dispatchEvent(new ClipboardEvent("paste", { clipboardData, bubbles: true, cancelable: true, composed: true }))
+        }, command)
+
+        // Let the legacy async Clipboard API path finish before submitting the shell command.
+        await new Promise((resolve) => setTimeout(resolve, 100))
+        await page.keyboard.press("Enter")
+
+        const deadline = Date.now() + 10000
+        let result = ""
+        while (Date.now() < deadline) {
+            try {
+                result = fs.readFileSync(sentinel, "utf8")
+            } catch {}
+            if (result !== "") break
+            await new Promise((resolve) => setTimeout(resolve, 50))
+        }
+        expect(result).toBe("X")
+    })
+})

--- a/test/frontend/__tests__/terminal_paste.js
+++ b/test/frontend/__tests__/terminal_paste.js
@@ -39,13 +39,18 @@ describe("SpaceStation terminal paste", () => {
         // browser's native paste event. Mocking the Clipboard API and delivering both events makes
         // Safari's double-delivery deterministic in Chromium: old code writes XX, fixed code X.
         await page.evaluateOnNewDocument((text) => {
+            window.__clipboardReadCalls = 0
             Object.defineProperty(navigator, "clipboard", {
                 configurable: true,
                 value: {
                     read: async () => {
+                        window.__clipboardReadCalls += 1
                         throw new Error("force the legacy readText fallback")
                     },
-                    readText: async () => text,
+                    readText: async () => {
+                        window.__clipboardReadCalls += 1
+                        return text
+                    },
                     writeText: async () => {},
                 },
             })
@@ -79,5 +84,6 @@ describe("SpaceStation terminal paste", () => {
             await new Promise((resolve) => setTimeout(resolve, 50))
         }
         expect(result).toBe("X")
+        expect(await page.evaluate(() => window.__clipboardReadCalls)).toBe(0)
     })
 })


### PR DESCRIPTION
## What changed
- let xterm exclusively handle native text paste, removing the competing Cmd+V Clipboard API path
- avoid browser-wide clickable paste/clipboard-read permission prompts for keyboard text paste
- preserve image paste through the native ClipboardEvent payload without requiring Clipboard API permission
- intercept image paste in capture phase so mixed image/text clipboard data cannot leak text into the shell
- add a deterministic browser regression against a real shell that proves text pastes once and invokes zero clipboard-read APIs

## Validation
- focused terminal paste browser E2E passes
- frontend TypeScript check passes
- JavaScript syntax and diff checks pass