### PR TITLE
Fix duplicate terminal creation on hard refresh

### DIFF
--- a/frontend/land.js
+++ b/frontend/land.js
@@ -1051,6 +1051,7 @@ const Land = () => {
     const [terminals, set_terminals] = useState(/** @type {Array<{tid: String, label: String}>} */ ([]))
     const [active_terminal, set_active_terminal] = useState(/** @type {String?} */ (null))
     const terminals_workspace = useRef(/** @type {String?} */ (null))
+    const [terminals_loaded_for, set_terminals_loaded_for] = useState(/** @type {String?} */ (null))
     const terminal_seq = useRef(/** @type {Number} */ (-1))
 
     // Terminal tabs belong to a workspace, not the browser origin. The old global localStorage
@@ -1065,6 +1066,10 @@ const Land = () => {
         set_active_terminal(restored.length ? restored[restored.length - 1].tid : null)
         const nums = restored.map((t) => parseInt(String(t.label ?? "").replace(/[^0-9]/g, ""), 10)).filter((x) => !isNaN(x))
         terminal_seq.current = nums.length ? Math.max(...nums) : 0
+        // The state updates above land on the next render. Until then, `terminals` still belongs to
+        // the previous render/workspace and must neither be persisted nor treated as an empty list
+        // that needs a brand-new terminal.
+        set_terminals_loaded_for(root)
     }, [workspace?.root])
 
     useEffect(() => {
@@ -1078,8 +1083,8 @@ const Land = () => {
 
     useEffect(() => {
         const root = workspace?.root ?? null
-        if (root != null && terminals_workspace.current === root) save_terminals(root, terminals)
-    }, [terminals, workspace?.root])
+        if (root != null && terminals_workspace.current === root && terminals_loaded_for === root) save_terminals(root, terminals)
+    }, [terminals, terminals_loaded_for, workspace?.root])
 
     // Warn before a browser close/reload discards unsaved FILE edits. File buffers are client-only
     // until Save hits ./api/v1/file/save; notebooks persist server-side, and terminals reattach on
@@ -1154,10 +1159,20 @@ const Land = () => {
         })
     }, [])
 
-    // opening the terminal panel with no terminals yet spins up the first one
+    // Opening the terminal panel with no terminals yet spins up the first one, but only AFTER the
+    // saved list for this workspace has reached React state. On a hard refresh `terminal_open` is
+    // restored synchronously while the terminal list is loaded in an effect; without this gate the
+    // pre-load empty state creates a duplicate beside the restored terminal.
     useEffect(() => {
-        if (terminal_open && workspace?.root != null && terminals_workspace.current === workspace.root && terminals.length === 0) new_terminal()
-    }, [terminal_open, terminals.length, workspace?.root])
+        if (
+            terminal_open &&
+            workspace?.root != null &&
+            terminals_workspace.current === workspace.root &&
+            terminals_loaded_for === workspace.root &&
+            terminals.length === 0
+        )
+            new_terminal()
+    }, [terminal_open, terminals.length, terminals_loaded_for, workspace?.root])
 
 
     const refresh = useCallback(async () => {

--- a/test/frontend/__tests__/terminal_paste.js
+++ b/test/frontend/__tests__/terminal_paste.js
@@ -90,13 +90,18 @@ describe("SpaceStation terminal", () => {
 
     it("restores an open terminal on hard refresh without creating another", async () => {
         page = await createPage(browser)
-        await page.goto(getPlutoUrl(), { waitUntil: "domcontentloaded" })
-        await page.evaluate(() => {
+        // This browser context is shared with the paste test above. Reset its terminal state before
+        // Land mounts, not afterward: a mounted page with `terminal_open=true` can race our cleanup
+        // by persisting that state again. The session marker keeps the saved terminal intact on the
+        // hard refresh that this test is meant to exercise.
+        await page.evaluateOnNewDocument(() => {
+            if (sessionStorage.getItem("spacestation terminal refresh test initialized") === "true") return
             localStorage.removeItem("spacestation terminals by workspace")
             localStorage.removeItem("spacestation terminals")
             localStorage.removeItem("spacestation terminal open")
+            sessionStorage.setItem("spacestation terminal refresh test initialized", "true")
         })
-        await page.reload({ waitUntil: "domcontentloaded" })
+        await page.goto(getPlutoUrl(), { waitUntil: "domcontentloaded" })
 
         await page.waitForSelector("button.terminal-toggle", { visible: true })
         await page.click("button.terminal-toggle")

--- a/test/frontend/__tests__/terminal_paste.js
+++ b/test/frontend/__tests__/terminal_paste.js
@@ -5,7 +5,7 @@ import puppeteer from "puppeteer"
 import { createPage } from "../helpers/common"
 import { getPlutoUrl } from "../helpers/pluto"
 
-describe("SpaceStation terminal paste", () => {
+describe("SpaceStation terminal", () => {
     /** @type {import("puppeteer").Browser} */
     let browser = null
     /** @type {import("puppeteer").Page} */
@@ -86,5 +86,43 @@ describe("SpaceStation terminal paste", () => {
         }
         expect(result).toBe("X")
         expect(await page.evaluate(() => window.__clipboardReadCalls)).toBe(0)
+    })
+
+    it("restores an open terminal on hard refresh without creating another", async () => {
+        page = await createPage(browser)
+        await page.goto(getPlutoUrl(), { waitUntil: "domcontentloaded" })
+        await page.evaluate(() => {
+            localStorage.removeItem("spacestation terminals by workspace")
+            localStorage.removeItem("spacestation terminals")
+            localStorage.removeItem("spacestation terminal open")
+        })
+        await page.reload({ waitUntil: "domcontentloaded" })
+
+        await page.waitForSelector("button.terminal-toggle", { visible: true })
+        await page.click("button.terminal-toggle")
+        await page.waitForSelector(".terminal-host .xterm-helper-textarea", { visible: true, timeout: 30000 })
+        await page.waitForFunction(() => document.querySelectorAll(".terminal-tab .title").length === 1)
+        await page.waitForFunction(() => {
+            const saved = Object.values(JSON.parse(localStorage.getItem("spacestation terminals by workspace") ?? "{}"))
+            return saved.flat().length === 1
+        })
+
+        const original_tid = await page.evaluate(() => {
+            const saved = Object.values(JSON.parse(localStorage.getItem("spacestation terminals by workspace") ?? "{}"))
+            return saved.flat()[0]?.tid ?? null
+        })
+        expect(original_tid).not.toBeNull()
+
+        await page.reload({ waitUntil: "domcontentloaded" })
+        await page.waitForSelector(".terminal-host .xterm-helper-textarea", { visible: true, timeout: 30000 })
+        // Let all post-load effects settle; the old race appended Terminal 2 here.
+        await new Promise((resolve) => setTimeout(resolve, 500))
+
+        expect(await page.$$eval(".terminal-tab .title", (tabs) => tabs.map((tab) => tab.getAttribute("title")))).toEqual(["Terminal 1"])
+        const restored_tids = await page.evaluate(() => {
+            const saved = Object.values(JSON.parse(localStorage.getItem("spacestation terminals by workspace") ?? "{}"))
+            return saved.flat().map((terminal) => terminal.tid)
+        })
+        expect(restored_tids).toEqual([original_tid])
     })
 })


### PR DESCRIPTION
## What changed
- gate terminal persistence and auto-creation until the saved tab list has loaded for the active workspace
- preserve and reattach the existing terminal ID instead of appending a new terminal during hard refresh
- add a real-browser regression that opens Terminal 1, hard-refreshes, and verifies one tab with the same terminal ID

## Root cause
The panel-open preference is restored synchronously, while workspace terminal tabs are restored in an effect. The auto-create effect observed the pre-restore empty array in that same render and appended a second terminal.

## Validation
- terminal browser E2E suite passes (paste + hard-refresh restoration)
- frontend TypeScript check passes
- JavaScript syntax and diff checks pass

## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/GroupTherapyOrg/SpaceStation.jl", rev="fix-terminal-refresh-duplicate")
julia> using SpaceStation
```
