### PR TITLE
fix: build the folder picker's paths on the server, not in the browser

### DIFF
--- a/frontend/land.js
+++ b/frontend/land.js
@@ -219,7 +219,7 @@ const FileEntry = ({ entry, listings, expanded, on_toggle, on_open_notebook, on_
  *  `on_cancel` (optional) shows a back button when opened on top of an existing workspace. */
 const WorkspaceOpener = ({ on_cancel, tunneled }) => {
     const [listing, set_listing] = useState(
-        /** @type {{path: String, parent: String, dirs: Array<String>, entries: Array<{name: String, path: String}>, crumbs: Array<{name: String, path: String}>}?} */ (null)
+        /** @type {{path: String, parent: String, entries: Array<{name: String, path: String}>, crumbs: Array<{name: String, path: String}>}?} */ (null)
     )
     const [error, set_error] = useState(/** @type {String?} */ (null))
     const [ssh_hosts, set_ssh_hosts] = useState(/** @type {Array<String>} */ ([]))
@@ -406,9 +406,8 @@ const WorkspaceOpener = ({ on_cancel, tunneled }) => {
 
     const recent = get_recent_workspaces()
 
-    // "/Users/dale/dev" → [{name: "/", path: "/"}, {name: "Users", path: "/Users"}, …], built by the
-    // server: splitting on "/" here turned a Windows path into one bogus crumb ("/C:\\Users\\dale"),
-    // and joining one back together would mean knowing about drives and backslashes in the browser.
+    // Built by the server: splitting a path on "/" here turned a Windows one into a single bogus
+    // crumb, and joining one back together means knowing about drives and backslashes.
     const crumbs = listing?.crumbs ?? []
 
     return html`<div class="workspace-opener">

--- a/frontend/land.js
+++ b/frontend/land.js
@@ -218,7 +218,9 @@ const FileEntry = ({ entry, listings, expanded, on_toggle, on_open_notebook, on_
  *  Picking a folder spawns a child server in a new tab (see connect_local); this view never leaves.
  *  `on_cancel` (optional) shows a back button when opened on top of an existing workspace. */
 const WorkspaceOpener = ({ on_cancel, tunneled }) => {
-    const [listing, set_listing] = useState(/** @type {{path: String, parent: String, dirs: Array<String>}?} */ (null))
+    const [listing, set_listing] = useState(
+        /** @type {{path: String, parent: String, dirs: Array<String>, entries: Array<{name: String, path: String}>, crumbs: Array<{name: String, path: String}>}?} */ (null)
+    )
     const [error, set_error] = useState(/** @type {String?} */ (null))
     const [ssh_hosts, set_ssh_hosts] = useState(/** @type {Array<String>} */ ([]))
     const [ssh_timeout, set_ssh_timeout] = useState(get_ssh_timeout)
@@ -404,17 +406,10 @@ const WorkspaceOpener = ({ on_cancel, tunneled }) => {
 
     const recent = get_recent_workspaces()
 
-    // "/Users/dale/dev" → [{name: "/", path: "/"}, {name: "Users", path: "/Users"}, …]
-    const crumbs =
-        listing == null
-            ? []
-            : [
-                  { name: "/", path: "/" },
-                  ...listing.path
-                      .split("/")
-                      .filter((s) => s !== "")
-                      .map((name, i, parts) => ({ name, path: "/" + parts.slice(0, i + 1).join("/") })),
-              ]
+    // "/Users/dale/dev" → [{name: "/", path: "/"}, {name: "Users", path: "/Users"}, …], built by the
+    // server: splitting on "/" here turned a Windows path into one bogus crumb ("/C:\\Users\\dale"),
+    // and joining one back together would mean knowing about drives and backslashes in the browser.
+    const crumbs = listing?.crumbs ?? []
 
     return html`<div class="workspace-opener">
         <div class="bubble opener-card">
@@ -483,16 +478,16 @@ const WorkspaceOpener = ({ on_cancel, tunneled }) => {
                                           title=${c.path}
                                       >
                                           ${c.name}</button
-                                      >${i < crumbs.length - 1 && c.name !== "/" ? html`<span class="crumb-sep">/</span>` : null}`
+                                      >${i > 0 && i < crumbs.length - 1 ? html`<span class="crumb-sep">/</span>` : null}`
                               )}
                           </nav>
                           <div class="dir-grid">
-                              ${listing.dirs.map(
-                                  (name) => html`<button class="dir-pill" title=${`${listing.path}/${name}`} onClick=${() => browse(`${listing.path}/${name}`)}>
-                                      <span class="dir-icon">📁</span>${name}
+                              ${listing.entries.map(
+                                  (d) => html`<button class="dir-pill" title=${d.path} onClick=${() => browse(d.path)}>
+                                      <span class="dir-icon">📁</span>${d.name}
                                   </button>`
                               )}
-                              ${listing.dirs.length === 0 ? html`<p class="subtitle">no subfolders</p>` : null}
+                              ${listing.entries.length === 0 ? html`<p class="subtitle">no subfolders</p>` : null}
                           </div>
                           <div class="opener-actions">
                               <button class="open-this-folder" onClick=${() => open_workspace(listing.path)}>

--- a/src/webserver/CollabAPI.jl
+++ b/src/webserver/CollabAPI.jl
@@ -197,6 +197,18 @@ function _within(root::String, path::String)
 end
 
 """
+`path` and its ancestors, root first, each as the name to show and the full path to browse to.
+
+The folder picker cannot build these itself: it would have to know that a Windows path separates
+with `\\` and starts with a drive (or a UNC share) rather than a `/`. `splitpath` and `joinpath`
+already know, and this is the side of the wire they live on.
+"""
+function _path_crumbs(path::String)
+    parts = splitpath(path)
+    [Pair["name" => parts[i], "path" => joinpath(parts[1:i]...)] for i in eachindex(parts)]
+end
+
+"""
 Listing of a workspace folder as JSON-able pairs, depth- and entry-budgeted. Bulky tool directories
 (and `.git`) are skipped, but dotfiles are shown.
 
@@ -620,7 +632,15 @@ function register_collab_api!(router, session::ServerSession)
                 isdir(joinpath(path, name)) && push!(dirs, name)
             end
         catch end
-        body = _json(Pair["path" => path, "parent" => dirname(path), "dirs" => dirs])
+        body = _json(Pair[
+            "path" => path,
+            "parent" => dirname(path),
+            "dirs" => dirs, # names only, as before — kept for anything curling this endpoint
+            # …and the same folders with the path already joined, so the browser never has to guess
+            # a separator. Same for the breadcrumbs of `path` itself.
+            "entries" => [Pair["name" => name, "path" => joinpath(path, name)] for name in dirs],
+            "crumbs" => _path_crumbs(path),
+        ])
         HTTP.Response(200, ["Content-Type" => "application/json; charset=utf-8"], body * "\n")
     end
     HTTP.register!(router, "GET", "/api/v1/browse", serve_api_browse)

--- a/src/webserver/CollabAPI.jl
+++ b/src/webserver/CollabAPI.jl
@@ -632,12 +632,11 @@ function register_collab_api!(router, session::ServerSession)
                 isdir(joinpath(path, name)) && push!(dirs, name)
             end
         catch end
+        # Folders and breadcrumbs both arrive with their paths already joined, so the browser never
+        # has to guess a separator to build one.
         body = _json(Pair[
             "path" => path,
             "parent" => dirname(path),
-            "dirs" => dirs, # names only, as before — kept for anything curling this endpoint
-            # …and the same folders with the path already joined, so the browser never has to guess
-            # a separator. Same for the breadcrumbs of `path` itself.
             "entries" => [Pair["name" => name, "path" => joinpath(path, name)] for name in dirs],
             "crumbs" => _path_crumbs(path),
         ])

--- a/test/WorkspaceTree.jl
+++ b/test/WorkspaceTree.jl
@@ -160,6 +160,20 @@ end
         end
     end
 
+    # The folder picker's breadcrumbs. They are built here rather than in the browser because the
+    # browser would have to know what a path looks like on the server's platform — splitting one on
+    # "/" turned `C:\\Users\\me` into a single bogus crumb, and rejoining it put a `/` in front.
+    @testset "breadcrumbs come apart and back together" begin
+        crumbs = [Dict(c) for c in Pluto._path_crumbs(joinpath(root, "a", "b"))]
+        @test [c["name"] for c in crumbs][end-1:end] == ["a", "b"]
+        @test crumbs[end]["path"] == joinpath(root, "a", "b")
+        # every crumb is a real prefix of the path, and one you can browse to
+        @test all(Pluto._within(crumbs[1]["path"], c["path"]) for c in crumbs)
+        @test crumbs[end-1]["path"] == joinpath(root, "a")
+        # the first crumb is the root of the filesystem, which is where the picker starts
+        @test Dict(Pluto._path_crumbs(homedir())[1])["path"] == splitpath(homedir())[1]
+    end
+
     @testset "a missing folder is empty, not an error" begin
         @test isempty(Pluto._workspace_entries(joinpath(root, "nope")))
     end

--- a/test/WorkspaceTree.jl
+++ b/test/WorkspaceTree.jl
@@ -160,16 +160,12 @@ end
         end
     end
 
-    # The folder picker's breadcrumbs. They are built here rather than in the browser because the
-    # browser would have to know what a path looks like on the server's platform — splitting one on
-    # "/" turned `C:\\Users\\me` into a single bogus crumb, and rejoining it put a `/` in front.
+    # The folder picker's breadcrumbs, built here because the browser would have to know what a path
+    # looks like on the server's platform: splitting `C:\Users\me` on "/" left one bogus crumb.
     @testset "breadcrumbs come apart and back together" begin
         crumbs = [Dict(c) for c in Pluto._path_crumbs(joinpath(root, "a", "b"))]
         @test [c["name"] for c in crumbs][end-1:end] == ["a", "b"]
-        @test crumbs[end]["path"] == joinpath(root, "a", "b")
-        # every crumb is a real prefix of the path, and one you can browse to
-        @test all(Pluto._within(crumbs[1]["path"], c["path"]) for c in crumbs)
-        @test crumbs[end-1]["path"] == joinpath(root, "a")
+        @test [c["path"] for c in crumbs][end-1:end] == [joinpath(root, "a"), joinpath(root, "a", "b")]
         # the first crumb is the root of the filesystem, which is where the picker starts
         @test Dict(Pluto._path_crumbs(homedir())[1])["path"] == splitpath(homedir())[1]
     end


### PR DESCRIPTION
Follow-on to #24, same class of bug one layer up.

`GET /api/v1/browse` answered with bare directory *names*, so the hub had to join them itself — and it built the breadcrumb bar by splitting `listing.path` on `"/"`:

```js
{ name: "/", path: "/" },
...listing.path.split("/").filter((s) => s !== "")
    .map((name, i, parts) => ({ name, path: "/" + parts.slice(0, i + 1).join("/") }))
```

On Windows a path like `C:\Users\me` survives that split whole, so the bar rendered **one** crumb, and rejoining put a `/` in front of it — clicking it browsed to `/C:\Users\me`, which does not exist. The folder pills had the same shape (`${listing.path}/${name}`); those happened to work only because `tamepath` normalizes mixed separators server-side.

## Change

The endpoint hands back paths that are already joined, and the browser stops building any:

- `entries` — each subfolder as `{name, path}`, joined with `joinpath` (replaces `dirs`)
- `crumbs` — the ancestors of `path`, from `splitpath`, each as `{name, path}`

The crumb separator now keys off "is this the first component" rather than `name !== "/"`, since on Windows the root component is `C:\`.

Same reasoning as #24's confinement fix: the server is the side that knows whether a path separates with `/` or `\` and what sits at the front of it, so it should be the side taking paths apart and putting them together.

## Testing

- `test/WorkspaceTree.jl` — 3 new assertions on `_path_crumbs`: the components come back in order, each carries the path joined up to that point, and the first is the filesystem root. **83/83 pass.**
- `tsc --noEmit` clean (typescript 5.9.3, matching CI).
- Verified against a running server, not just in unit tests:

```
browse <ws>                    → 200  {"path":…,"parent":…,"entries":[{"name":"sub","path":"<ws>/sub"}],"crumbs":[{"name":"/","path":"/"},…]}
workspace root                 → 200
listing <ws>/sub               → 200
listing /etc                   → 403  path is outside the workspace
listing <ws>_other             → 403  path is outside the workspace
```

That last one is the prefix-sharing sibling — confirmation that the component-wise confinement from #24 behaves on a real request, not only in the unit test.

## Not in scope

`create_in` still builds `` `${dir}/${name}` `` for the create request. It works — both `/api/v1/file/new` and `/move` run it through `tamepath` — but on Windows the un-normalized string is what lands in the tab's `path`, so a tab opened that way won't match the same file opened from the tree. Cosmetic, separate fix.