### PR TITLE
ci: dispatch desktop installer builds from release-please

### DIFF
--- a/.github/workflows/Desktop.yml
+++ b/.github/workflows/Desktop.yml
@@ -22,6 +22,13 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Attach installers + install guide to this existing release (e.g. v0.4.0). The ReleasePlease workflow dispatches this automatically — releases it creates with GITHUB_TOKEN cannot trigger the `release` event."
+        required: false
+        type: string
+        default: ""
+
 
 permissions:
   contents: write # attach installers + edit notes on releases; read-only for everything else we do
@@ -119,17 +126,17 @@ jobs:
           path: desktop/dist/${{ matrix.file }}
           if-no-files-found: error
       - name: Attach to release
-        if: github.event_name == 'release'
+        if: github.event_name == 'release' || inputs.release_tag != ''
         env:
           GH_TOKEN: ${{ github.token }}
         working-directory: desktop
-        run: gh release upload "${{ github.event.release.tag_name }}" "dist/${{ matrix.file }}" --clobber
+        run: gh release upload "${{ github.event.release.tag_name || inputs.release_tag }}" "dist/${{ matrix.file }}" --clobber
 
   # Release notes get the install guide appended (once): download table + the one-time
   # unsigned-build workarounds, until signing credentials exist.
   release-notes:
     name: release install guide
-    if: github.event_name == 'release'
+    if: github.event_name == 'release' || inputs.release_tag != ''
     needs: build
     runs-on: ubuntu-latest
     steps:
@@ -137,7 +144,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          TAG="${{ github.event.release.tag_name }}"
+          TAG="${{ github.event.release.tag_name || inputs.release_tag }}"
           gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json body --jq .body > notes.md
           if grep -q "## Install the desktop app" notes.md; then exit 0; fi
           cat >> notes.md <<'EOF'

--- a/.github/workflows/ReleasePlease.yml
+++ b/.github/workflows/ReleasePlease.yml
@@ -41,6 +41,22 @@ jobs:
                   config-file: release-please-config.json
                   manifest-file: .release-please-manifest.json
 
+    # Releases created here use GITHUB_TOKEN (no PAT configured), and such events cannot trigger
+    # other workflows — so the Desktop installer build is DISPATCHED explicitly (an explicit
+    # workflow_dispatch API call from GITHUB_TOKEN is allowed). It builds the .dmg/.msi/.AppImage
+    # set, attaches them to the release, and appends the install guide to its notes.
+    desktop-installers:
+        name: Build desktop installers for the release
+        needs: release-please
+        if: ${{ needs.release-please.outputs.release_created == 'true' }}
+        runs-on: ubuntu-latest
+        permissions:
+            actions: write
+        steps:
+            - env:
+                  GH_TOKEN: ${{ github.token }}
+              run: gh workflow run Desktop.yml --repo "$GITHUB_REPOSITORY" -f release_tag="${{ needs.release-please.outputs.tag_name }}"
+
     register:
         name: Register in JuliaRegistries/General
         needs: release-please


### PR DESCRIPTION
The Desktop workflow's `release: published` trigger can never fire: release-please creates releases with `GITHUB_TOKEN` (no PAT configured), and events created with `GITHUB_TOKEN` don't trigger other workflows — v0.4.0 published with no installers attached.

Fix: explicit `workflow_dispatch` API calls from `GITHUB_TOKEN` ARE allowed, so ReleasePlease now dispatches `Desktop.yml` with the new tag (`actions: write`), and `Desktop.yml` accepts a `release_tag` input routing the attach + release-notes steps to that release. Also usable for manual backfills (v0.4.0 will be first).

## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/GroupTherapyOrg/SpaceStation.jl", rev="ci/release-installer-dispatch")
julia> using SpaceStation
```
