### PR TITLE
fix: give release installer builds their own concurrency lane

### DIFF
--- a/.github/workflows/Desktop.yml
+++ b/.github/workflows/Desktop.yml
@@ -34,7 +34,10 @@ permissions:
   contents: write # attach installers + edit notes on releases; read-only for everything else we do
 
 concurrency:
-  group: desktop-${{ github.ref }}
+  # Release builds get their OWN lane: they are dispatched from ReleasePlease at the same moment
+  # the release commit lands on main, and sharing a group with the ordinary push build meant one
+  # cancelled the other (v0.4.0's installer backfill died exactly this way).
+  group: desktop-${{ github.ref }}-${{ inputs.release_tag || 'ci' }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
ReleasePlease dispatches the Desktop workflow at the same moment the release commit lands on `main`, so the dispatched run and the ordinary push run shared the concurrency group `desktop-<ref>` and cancelled each other — which is exactly how v0.4.0's installer backfill died.

The group now includes the release tag, so release builds never race ordinary CI builds.

## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/GroupTherapyOrg/SpaceStation.jl", rev="fix/release-build-concurrency")
julia> using SpaceStation
```
