### PR TITLE
docs: macOS install needs a local re-sign, not just quarantine removal

### DIFF
--- a/.github/workflows/Desktop.yml
+++ b/.github/workflows/Desktop.yml
@@ -179,24 +179,22 @@ jobs:
           These builds are **not code-signed yet**, so each OS asks once before it will run a new
           app. Nothing here is permanent; it is the same step you take for any unsigned download.
 
-          **macOS** — open the `.dmg`, drag **SpaceStation** into **Applications**, then paste this
-          into Terminal:
+          **macOS** — open the `.dmg` and drag **SpaceStation** into **Applications** (do not run it
+          from the disk image). Then paste both lines into Terminal:
 
           ```sh
           xattr -dr com.apple.quarantine "/Applications/SpaceStation.app"
+          codesign --force --deep --sign - "/Applications/SpaceStation.app"
           ```
 
-          Then open SpaceStation normally. (No admin rights? Drag it to `~/Applications` instead and
-          use that path in the command.)
+          Then open SpaceStation normally. The first line clears the download quarantine; the second
+          re-signs the app locally, which is what clears *"SpaceStation is damaged and can't be
+          opened"* — macOS shows that wording for any app that isn't signed with a paid Developer ID,
+          and on Apple Silicon clearing quarantine alone is often not enough. Nothing is actually
+          damaged. (No admin rights? Drag it to `~/Applications` instead and use that path in both
+          commands.)
 
-          <details>
-          <summary>Prefer not to use Terminal?</summary>
-
-          Double-click the app, and when macOS blocks it go to **System Settings → Privacy &
-          Security**, scroll to the message about SpaceStation, and click **Open Anyway**. Then open
-          the app again and choose **Open**.
-
-          </details>
+          Both steps disappear once the project has an Apple Developer ID and releases are notarized.
 
           **Windows** — double-click `SpaceStation-win-x64.msi`. If SmartScreen shows *"Windows
           protected your PC"*, click **More info → Run anyway**.

--- a/README.md
+++ b/README.md
@@ -57,13 +57,18 @@ Download from the [latest release](https://github.com/GroupTherapyOrg/SpaceStati
 
 The builds aren't code-signed yet, so each OS asks once before it will run a new app.
 
-**macOS** — drag **SpaceStation** into **Applications**, then paste this into Terminal:
+**macOS** — drag **SpaceStation** into **Applications** (don't run it from the disk image), then
+paste both lines into Terminal:
 
 ```sh
 xattr -dr com.apple.quarantine "/Applications/SpaceStation.app"
+codesign --force --deep --sign - "/Applications/SpaceStation.app"
 ```
 
-(Or right-click the app → **Open**, then **System Settings → Privacy & Security → Open Anyway**.)
+The first line clears the download quarantine; the second re-signs the app locally, which is what
+clears *"SpaceStation is damaged and can't be opened"* — macOS uses that wording for any app not
+signed with a paid Developer ID, and on Apple Silicon clearing quarantine alone is often not
+enough. Nothing is actually damaged. Both steps go away once releases are notarized.
 
 **Windows** — double-click the `.msi`; if SmartScreen appears, choose **More info → Run anyway**.
 


### PR DESCRIPTION
A downloaded build reports **"SpaceStation is damaged and can't be opened"** — macOS's wording for any app not signed with a paid Developer ID. Clearing the download quarantine alone was **not enough** on Apple Silicon; the app also has to be re-signed locally (ad-hoc) before it will launch.

Release-notes guide and README now give both commands, explain nothing is actually damaged, warn against running from the mounted disk image, and note both steps vanish once releases are notarized.

Dropped the right-click → *Open Anyway* fallback: it doesn't work for the "damaged" case, so offering it only wastes the user's time.

## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/GroupTherapyOrg/SpaceStation.jl", rev="docs/macos-resign-step")
julia> using SpaceStation
```
