### PR TITLE
fix: theme toggle must not blank views or lose scrollbars in the desktop app

### DIFF
--- a/desktop/deck.ts
+++ b/desktop/deck.ts
@@ -173,6 +173,14 @@ export const deck_html = (launcher_url: string) => /* html */ `<!doctype html>
                     sessionStorage.setItem("spacestation deck scheme", scheme)
                 } catch {}
                 for (const f of stage.querySelectorAll("iframe")) send_scheme(f)
+                // The shell flips the native window appearance to match (macOS): WKWebView's own
+                // chrome (scrollbars, form controls) follows the window, not the page's CSS, and
+                // repaints reliably only through this native path. Also persists the choice.
+                fetch("./api/appearance", {
+                    method: "POST",
+                    headers: { "content-type": "application/json" },
+                    body: JSON.stringify({ scheme }),
+                }).catch(() => {})
             }
         })
         render()

--- a/desktop/julia.ts
+++ b/desktop/julia.ts
@@ -15,7 +15,7 @@ export type JuliaSettings = { channel: string | null; ask: boolean }
 
 const settings_path = () => `${data_dir()}/settings.json`
 
-export const load_settings = (): { julia?: JuliaSettings } => {
+export const load_settings = (): { julia?: JuliaSettings; color_scheme?: "light" | "dark" | "system" } => {
     try {
         return JSON.parse(Deno.readTextFileSync(settings_path()))
     } catch {

--- a/desktop/macos_titlebar.ts
+++ b/desktop/macos_titlebar.ts
@@ -21,6 +21,7 @@ const objc = (): any | null => {
             sel_registerName: { parameters: ["buffer"], result: "pointer" },
             msg_ptr: { name: "objc_msgSend", parameters: ["pointer", "pointer"], result: "pointer" },
             msg_ptr_buf: { name: "objc_msgSend", parameters: ["pointer", "pointer", "buffer"], result: "pointer" },
+            msg_ptr_parg: { name: "objc_msgSend", parameters: ["pointer", "pointer", "pointer"], result: "pointer" },
             msg_ptr_u64arg: { name: "objc_msgSend", parameters: ["pointer", "pointer", "u64"], result: "pointer" },
             msg_ptr_i64arg: { name: "objc_msgSend", parameters: ["pointer", "pointer", "i64"], result: "pointer" },
             msg_u64: { name: "objc_msgSend", parameters: ["pointer", "pointer"], result: "u64" },
@@ -69,6 +70,38 @@ export const extend_under_titlebar = (): boolean => {
         return ok && applied
     } catch (e) {
         console.warn("could not extend content under the title bar:", e)
+        return false
+    }
+}
+
+/** Pin the whole app to light/dark (or back to following the OS). WKWebView resolves
+ *  prefers-color-scheme from the hosting window's effective appearance, so this flips the web
+ *  content's theme the same way a real OS dark-mode switch does — a path WebKit repaints
+ *  correctly, native scrollbars included. (Rewriting color-scheme purely from CSS inside the
+ *  webview left WKWebView with stale scrollbar/compositor state; see the v0.4.2 theme-toggle
+ *  regressions.) Set on NSApplication so every current and future window follows. KVC maps
+ *  NSNull back to nil, which restores "follow the system". */
+export const set_app_appearance = (scheme: "light" | "dark" | "system"): boolean => {
+    try {
+        const S = objc()
+        if (S == null) return false
+        const cls = (n: string) => S.objc_getClass(cstr(n))
+        const sel = (n: string) => S.sel_registerName(cstr(n))
+        const nsstr = (s: string) => S.msg_ptr_buf(cls("NSString"), sel("stringWithUTF8String:"), cstr(s))
+        const app = S.msg_ptr(cls("NSApplication"), sel("sharedApplication"))
+        const value =
+            scheme === "system"
+                ? S.msg_ptr(cls("NSNull"), sel("null"))
+                : S.msg_ptr_parg(cls("NSAppearance"), sel("appearanceNamed:"), nsstr(scheme === "dark" ? "NSAppearanceNameDarkAqua" : "NSAppearanceNameAqua"))
+        // A nil here (AppKit missing, unknown appearance name) must NOT reach setObject:forKey: —
+        // that throws an ObjC exception straight through the FFI, killing the process.
+        if (app === null || value === null) return false
+        const dict = S.msg_ptr(cls("NSMutableDictionary"), sel("dictionary"))
+        S.msg_void_pp(dict, sel("setObject:forKey:"), value, nsstr("appearance"))
+        S.msg_void_ppi8(app, sel("performSelectorOnMainThread:withObject:waitUntilDone:"), sel("setValuesForKeysWithDictionary:"), dict, 1)
+        return true
+    } catch (e) {
+        console.warn("could not set the app appearance:", e)
         return false
     }
 }

--- a/desktop/main.ts
+++ b/desktop/main.ts
@@ -11,7 +11,7 @@
 
 import { SpaceStationServer, type BootOptions } from "./boot.ts"
 import { serve_ui } from "./splash.ts"
-import { extend_under_titlebar } from "./macos_titlebar.ts"
+import { extend_under_titlebar, set_app_appearance } from "./macos_titlebar.ts"
 import { has_plain_julia, julia_catalog, juliaup_info, load_settings, save_settings } from "./julia.ts"
 
 // Deno.BrowserWindow only exists inside the desktop runtime host. Fail with a hint, not a crash,
@@ -26,6 +26,11 @@ if (BrowserWindow == null) {
 // the content under the title bar, so the deck's tab strip shares the traffic lights' row.
 const win = new BrowserWindow({ title: "", width: 1280, height: 878, transparentTitlebar: true })
 const under_titlebar = extend_under_titlebar()
+
+// The launcher's theme choice pins the native window appearance (macOS — a no-op elsewhere), so
+// WKWebView's prefers-color-scheme and its own chrome follow it like a real OS dark-mode switch.
+const saved_scheme = load_settings().color_scheme
+if (saved_scheme === "light" || saved_scheme === "dark") set_app_appearance(saved_scheme)
 
 const shell_port = Deno.env.get("DENO_SERVE_ADDRESS")?.split(":").pop()
 const shell_url = (path: string) => `http://127.0.0.1:${shell_port}${path}`
@@ -103,6 +108,10 @@ serve_ui({
         // Fire and return: start() leaves "idle" synchronously, so the page's redirect to "/"
         // lands on the live splash; progress (installs included) streams there.
         void server.start({ channel: opts.channel, add_channel: opts.add_channel, update: opts.update, bootstrap: opts.bootstrap })
+    },
+    on_appearance: (scheme) => {
+        save_settings({ color_scheme: scheme })
+        set_app_appearance(scheme)
     },
 })
 

--- a/desktop/splash.ts
+++ b/desktop/splash.ts
@@ -65,15 +65,26 @@ export interface UiHandlers {
     state: () => BootState
     julia_info: () => Promise<unknown>
     on_launch: (opts: BootOptions & { remember?: boolean }) => Promise<void>
+    on_appearance?: (scheme: "light" | "dark" | "system") => void
 }
 
-export const serve_ui = ({ state, julia_info, on_launch }: UiHandlers) =>
+export const serve_ui = ({ state, julia_info, on_launch, on_appearance }: UiHandlers) =>
     Deno.serve(async (req) => {
         const path = new URL(req.url).pathname
         const json = (body: unknown) => new Response(JSON.stringify(body), { headers: { "content-type": "application/json" } })
         const page = (html: string) => new Response(html, { headers: { "content-type": "text/html; charset=utf-8" } })
         if (path === "/status") return json(state())
         if (path === "/api/julia") return json(await julia_info())
+        if (path === "/api/appearance" && req.method === "POST") {
+            try {
+                const { scheme } = await req.json()
+                if (scheme !== "light" && scheme !== "dark" && scheme !== "system") return new Response("bad scheme", { status: 400 })
+                on_appearance?.(scheme)
+                return json({ ok: true })
+            } catch (e) {
+                return new Response(String(e), { status: 500 })
+            }
+        }
         if (path === "/api/julia/launch" && req.method === "POST") {
             try {
                 await on_launch(await req.json())

--- a/frontend/common/ColorScheme.js
+++ b/frontend/common/ColorScheme.js
@@ -1,7 +1,8 @@
 // App-wide light/dark override. Pluto's themes are `@media (prefers-color-scheme: …)` blocks
 // (themes/light.css + themes/dark.css, plus scattered blocks in other sheets), which JS cannot
-// toggle with a class — but CSSOM lets us rewrite each rule's media condition: forcing dark turns
-// the dark blocks into `all` and the light blocks into `not all` (and back). One stored choice —
+// toggle with a class — but CSSOM lets us rewrite each rule's media condition: the color-scheme
+// CLAUSE (and only that clause) becomes always-true or never-true, so a compound condition like
+// `(max-width: 700px) and (prefers-color-scheme: dark)` keeps its other clauses. One stored choice —
 // "system" | "light" | "dark" — applies to every same-origin page: the hub, the editor iframes
 // inside it, and standalone editor tabs, kept live via `storage` events. (The integrated
 // terminal's own scheme toggle is deliberately separate — a light UI with a dark terminal is a
@@ -38,37 +39,54 @@ export const prefers_dark = () => {
     return window.matchMedia("(prefers-color-scheme: dark)").matches
 }
 
-// A rule's original identity (dark-block or light-block) is unrecoverable once its condition has
-// been rewritten to all/not all — remember it the first time we see the rule.
-const identity = new WeakMap()
+// A rewritten condition no longer contains prefers-color-scheme, so remember each rule's
+// ORIGINAL condition the first time we see it; every later pass rewrites from that string.
+const original_condition = new WeakMap()
+
+// Substituted for the color-scheme clause ONLY — never the whole condition. A compound query
+// like (max-width: 700px) and (prefers-color-scheme: dark) must keep its width clause, or
+// forcing dark turns mobile-only rules on at desktop width.
+const ALWAYS = "(min-width: 0px)"
+const NEVER = "(min-width: 999999px)"
+
+const rewrite = (rule, scheme) => {
+    let orig = original_condition.get(rule)
+    if (orig == null) {
+        if (!/prefers-color-scheme/i.test(rule.media.mediaText)) return
+        orig = rule.media.mediaText
+        original_condition.set(rule, orig)
+    }
+    const next =
+        scheme === "system"
+            ? orig
+            : orig.replace(/\(\s*prefers-color-scheme\s*:\s*(light|dark)\s*\)/gi, (_, want) => (want.toLowerCase() === scheme ? ALWAYS : NEVER))
+    if (rule.media.mediaText !== next) rule.media.mediaText = next
+}
 
 const apply = (scheme) => {
     // The media rewrite below only governs AUTHOR styles — the UA still colors its own defaults
     // (default text, form controls, scrollbars) from the page's declared color-scheme and the OS.
     // With a dark OS and a forced-light page that meant white UA text on light backgrounds
     // (invisible buttons, washed-out logs). The color-scheme PROPERTY on :root overrides the
-    // meta and pins the UA side too.
+    // meta and pins the UA side too. (The desktop shell additionally flips the native window
+    // appearance to match, so WKWebView's own chrome — scrollbars included — follows along.)
     document.documentElement.style.colorScheme = scheme === "system" ? "" : scheme
-    const walk = (sheet) => {
-        let rules
-        try {
-            rules = sheet.cssRules
-        } catch (e) {
-            return // cross-origin sheet: not ours, not our themes
-        }
+    const walk_rules = (rules) => {
         for (const rule of rules) {
             if (rule.styleSheet != null) {
                 walk(rule.styleSheet) // @import
                 continue
             }
-            if (rule.media == null) continue
-            let kind = identity.get(rule)
-            if (kind == null && /prefers-color-scheme/.test(rule.media.mediaText)) {
-                kind = rule.media.mediaText.includes("dark") ? "dark" : "light"
-                identity.set(rule, kind)
-            }
-            if (kind == null) continue
-            rule.media.mediaText = scheme === "system" ? `(prefers-color-scheme: ${kind})` : scheme === kind ? "all" : "not all"
+            if (rule.media != null) rewrite(rule, scheme)
+            // grouping rules (@media, @supports, @layer) can nest more media rules
+            if (rule.cssRules != null && rule.cssRules.length > 0) walk_rules(rule.cssRules)
+        }
+    }
+    const walk = (sheet) => {
+        try {
+            walk_rules(sheet.cssRules)
+        } catch (e) {
+            return // cross-origin sheet: not ours, not our themes
         }
     }
     // Shadow roots keep their own stylesheets (some components render in shadow DOM) — walk them


### PR DESCRIPTION
Fixes the two theme-toggle regressions reported in the desktop app: toggling any scheme made the notebook scrollbar vanish, and toggling dark blanked the workspace view.

**Diagnosis.** Both are WKWebView-specific (they do not reproduce in Chrome or Playwright WebKit driving the same live server):

1. The CSSOM rewrite replaced each rule's whole media condition with `all`/`not all`, flattening compound queries — and restoring *system* rebuilt only the color-scheme clause, permanently dropping any other clauses.
2. WKWebView paints its own chrome (scrollbars, form controls) from the hosting window's effective appearance, not from page CSS, so a CSS-only flip leaves stale scrollbar/compositor state.

**Fix.**
- `ColorScheme.js` substitutes only the `(prefers-color-scheme: …)` clause (always-true/never-true), remembers each rule's original condition, restores it exactly on *system*, and walks nested grouping rules.
- The deck reports the choice to the shell (`POST /api/appearance`); the shell pins `NSApplication.appearance` through the existing main-thread FFI trampoline (`NSNull` → follow the OS), persists it in `settings.json`, and reapplies at startup. So the desktop theme flips exactly like a native OS appearance switch — the path WKWebView repaints correctly, scrollbars included. No-op on Windows/Linux, where the (Chromium-verified) CSS path carries the toggle.

**Verification.** Playwright WebKit + real Chrome against a live workspace server: dark/light/system round-trips keep every tree row visible; a synthetic `(max-width: 700px) and (prefers-color-scheme: dark)` rule keeps its width clause in every state; original media text restores byte-identical; `deno check` and `tsc --noEmit` clean (the three pre-existing tsc errors on main are unchanged).

## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/GroupTherapyOrg/SpaceStation.jl", rev="fix/theme-toggle-webkit")
julia> using SpaceStation
```
