### PR TITLE
fix: fit the window to the screen and make shell pages draggable

### DIFF
--- a/desktop/launch.ts
+++ b/desktop/launch.ts
@@ -23,13 +23,18 @@ export const launch_html = /* html */ `<!doctype html>
 ${base_css}
     .rows { display: flex; flex-direction: column; gap: 0.45rem; }
     h2 .hint { font-weight: normal; text-transform: none; letter-spacing: normal; font-size: 0.78rem; opacity: 0.55; margin-left: 0.6rem; }
+    /* The footer bar owns the card's bottom edge: the card gives up its bottom padding and the
+       full-bleed sticky bar supplies it, so the scrolling list disappears cleanly under the bar
+       instead of peeking out through the padding gap beneath it. */
+    .card { padding-bottom: 0; }
     .footer {
-        display: flex; align-items: center; gap: 1rem; margin-top: 1.6rem;
-        position: sticky; bottom: 0; padding: 0.8rem 0 0.2rem; background: var(--card-bg-color, inherit);
+        display: flex; align-items: center; gap: 1rem;
+        position: sticky; bottom: 0; margin: 1.6rem -2rem 0; padding: 0.8rem 2rem 1.4rem;
+        background: var(--code-background); border-top: 1px solid var(--rule-color);
     }
     .remember { display: flex; align-items: center; gap: 0.45rem; font-size: 0.85rem; opacity: 0.8; cursor: pointer; user-select: none; }
     .remember input { accent-color: var(--accent); }
-    .note { font-size: 0.78rem; opacity: 0.55; margin-top: 0.9rem; }
+    .note { font-size: 0.78rem; opacity: 0.55; margin: 0.9rem 0 1.4rem; }
     .cancel { margin-left: auto; font-size: 0.85rem; opacity: 0.6; color: inherit; }
     #error { color: #ff8a8a; font-size: 0.85rem; margin-top: 0.8rem; }
     .pill.busy { box-shadow: inset 0 0 0 2px var(--accent); opacity: 1; }
@@ -50,6 +55,7 @@ ${base_css}
 </style>
 </head>
 <body>
+    <div class="dragbar"></div>
     <div class="bubble card">
         <header>
             ${logo_svg}

--- a/desktop/macos_titlebar.ts
+++ b/desktop/macos_titlebar.ts
@@ -106,6 +106,25 @@ export const set_app_appearance = (scheme: "light" | "dark" | "system"): boolean
     }
 }
 
+/** The main display's size in points (CoreGraphics reports the scaled mode's logical size), or
+ *  null off-macOS / on failure. Used to clamp the initial window so it cannot open larger than
+ *  the screen — the fixed default overflowed smaller displays, cutting off the bottom of every
+ *  shell page. Plain C calls, no structs, no AppKit dependency. */
+export const main_screen_size = (): { width: number; height: number } | null => {
+    if (Deno.build.os !== "darwin") return null
+    try {
+        const cg = Deno.dlopen("/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics", {
+            CGMainDisplayID: { parameters: [], result: "u32" },
+            CGDisplayPixelsWide: { parameters: ["u32"], result: "usize" },
+            CGDisplayPixelsHigh: { parameters: ["u32"], result: "usize" },
+        } as const).symbols
+        const id = cg.CGMainDisplayID()
+        return { width: Number(cg.CGDisplayPixelsWide(id)), height: Number(cg.CGDisplayPixelsHigh(id)) }
+    } catch {
+        return null
+    }
+}
+
 // NOTE: fullscreen-overlay tracking (auto-hiding the deck strip in sync with the native
 // fullscreen chrome) was implemented here and deliberately removed: between notch geometry, the
 // overlay stealing the mouse, and unrelated helper windows fooling the detection, it broke more

--- a/desktop/main.ts
+++ b/desktop/main.ts
@@ -11,7 +11,7 @@
 
 import { SpaceStationServer, type BootOptions } from "./boot.ts"
 import { serve_ui } from "./splash.ts"
-import { extend_under_titlebar, set_app_appearance } from "./macos_titlebar.ts"
+import { extend_under_titlebar, main_screen_size, set_app_appearance } from "./macos_titlebar.ts"
 import { has_plain_julia, julia_catalog, juliaup_info, load_settings, save_settings } from "./julia.ts"
 
 // Deno.BrowserWindow only exists inside the desktop runtime host. Fail with a hint, not a crash,
@@ -24,7 +24,16 @@ if (BrowserWindow == null) {
 
 // The first construction adopts the implicit startup window. On macOS the FFI tweak then extends
 // the content under the title bar, so the deck's tab strip shares the traffic lights' row.
-const win = new BrowserWindow({ title: "", width: 1280, height: 878, transparentTitlebar: true })
+// Never open larger than the screen: on smaller or scaled-down displays the fixed default
+// overflowed the visible area, cutting off the bottom of every page. (Margins leave room for
+// the menu bar and a bit of breathing space; off-macOS the defaults stand.)
+const screen = main_screen_size()
+const win = new BrowserWindow({
+    title: "",
+    width: screen ? Math.min(1280, screen.width - 32) : 1280,
+    height: screen ? Math.min(878, screen.height - 80) : 878,
+    transparentTitlebar: true,
+})
 const under_titlebar = extend_under_titlebar()
 
 // The launcher's theme choice pins the native window appearance (macOS — a no-op elsewhere), so

--- a/desktop/splash.ts
+++ b/desktop/splash.ts
@@ -33,6 +33,7 @@ ${base_css}
 </style>
 </head>
 <body>
+    <div class="dragbar"></div>
     <div class="bubble card">
         ${logo_svg}
         <h1>Space<span class="land-accent">Station</span></h1>

--- a/desktop/theme.ts
+++ b/desktop/theme.ts
@@ -32,6 +32,11 @@ export const base_css = /* css */ `
         background-color: var(--main-bg-color); color: var(--pluto-output-color);
         font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
     }
+    /* The window content extends under the (transparent, title-less) native title bar. The deck
+       has its tab strip as the grab area, but these shell pages had NOTHING draggable — the
+       window could not be moved at all, including to another display. This invisible strip is
+       that grab area. */
+    .dragbar { position: fixed; top: 0; left: 0; right: 0; height: 28px; -webkit-app-region: drag; }
     .bubble {
         background-color: var(--code-background); border-radius: 0.8rem;
         box-shadow: 0 0 0 1px var(--rule-color), -2px 5px 14px 0px #00000022;


### PR DESCRIPTION
Fixes the window problems reported on a smaller (1147×745pt) display:

- **Window larger than the screen** — the fixed 1280×878 default overflowed the display in both dimensions, cutting off the bottom of every page (the "aspect ratio" breakage). The initial size is now clamped to the main display's size via CoreGraphics (plain C calls, points; non-macOS keeps the defaults, and any FFI failure falls back to them too).
- **Window could not be dragged from the Launch Station** — content extends under the transparent title bar and only the deck's tab strip was marked `-webkit-app-region: drag`, so the launcher/splash windows had no grab area at all, making it impossible to move the window to another display. The shell pages now carry an invisible 28px drag strip along the top.
- **Launcher footer interleaved with the list** — the sticky footer was transparent, and WebKit insets sticky-bottom by the scroll container's padding, so rows rendered below and through the checkbox bar. The bar is now solid, full-bleed, and owns the card's bottom edge.

Verified in Playwright WebKit at the clamped size (1115×665): the list scrolls cleanly under the solid footer bar, top and fully-scrolled states both correct; `main_screen_size()` probed on-device (returns 1147×745); `deno check` clean across the shell.

## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/GroupTherapyOrg/SpaceStation.jl", rev="fix/window-fit-and-drag")
julia> using SpaceStation
```
