### PR TITLE
fix: window dragging via a native bridge, and recreate stale WKWebView scrollers

### DIFF
--- a/desktop/deck.ts
+++ b/desktop/deck.ts
@@ -50,6 +50,12 @@ export const deck_html = (launcher_url: string) => /* html */ `<!doctype html>
         const strip = document.getElementById("strip")
         const stage = document.getElementById("stage")
         document.body.classList.toggle("inset", new URLSearchParams(location.search).has("inset"))
+        // The strip's -webkit-app-region CSS is inert in WKWebView (a Chromium feature), so the
+        // window was never draggable from it. Instead: mousedown on strip background (not a tab)
+        // asks the shell to start a native window drag.
+        strip.addEventListener("mousedown", (e) => {
+            if (e.button === 0 && e.target.closest(".tab") == null) fetch("./api/drag", { method: "POST" }).catch(() => {})
+        })
         // NOTE: no fullscreen special-casing, deliberately. Auto-hiding the strip in sync with the
         // native fullscreen overlay was tried and looked broken more ways than it looked native
         // (notch geometry, the overlay stealing the mouse, unrelated helper windows). The strip is

--- a/desktop/launch.ts
+++ b/desktop/launch.ts
@@ -71,6 +71,12 @@ ${base_css}
         <div class="note" id="restart-note" style="display: none">Switching versions restarts the SpaceStation server — running notebooks stop.</div>
     </div>
     <script>
+        // WKWebView has no CSS drag regions — mousedown here asks the shell to start a native
+        // window drag (AppKit tracks it from there)
+        document.querySelector(".dragbar").addEventListener("mousedown", (e) => {
+            if (e.button === 0) fetch("./api/drag", { method: "POST" }).catch(() => {})
+        })
+
         const content = document.getElementById("content")
         let launching = false
 

--- a/desktop/macos_titlebar.ts
+++ b/desktop/macos_titlebar.ts
@@ -106,6 +106,37 @@ export const set_app_appearance = (scheme: "light" | "dark" | "system"): boolean
     }
 }
 
+/** Start a native window drag. WKWebView swallows every mouse event, so CSS app-region does
+ *  nothing in this shell (it is a Chromium feature) and the window had NO way to be moved.
+ *  The standard WKWebView-shell workaround: on mousedown in a page's drag area, the page calls
+ *  the shell, and the shell hands the in-flight mouse event to performWindowDragWithEvent: —
+ *  AppKit then runs the whole native drag session (tracking, spaces, displays) by itself.
+ *  currentEvent is read off-main (the JS thread), so the event is retained immediately and
+ *  deliberately never released — one leaked NSEvent per drag START is noise, and it removes
+ *  any chance of handing AppKit a freed pointer. */
+export const begin_window_drag = (): boolean => {
+    try {
+        const S = objc()
+        if (S == null) return false
+        const cls = (n: string) => S.objc_getClass(cstr(n))
+        const sel = (n: string) => S.sel_registerName(cstr(n))
+        const app = S.msg_ptr(cls("NSApplication"), sel("sharedApplication"))
+        if (app === null) return false
+        const ev = S.msg_ptr(app, sel("currentEvent"))
+        if (ev === null) return false
+        S.msg_ptr(ev, sel("retain"))
+        let started = false
+        each_titled_window((S2, w) => {
+            S2.msg_void_ppi8(w, sel("performSelectorOnMainThread:withObject:waitUntilDone:"), sel("performWindowDragWithEvent:"), ev, 0)
+            started = true
+        })
+        return started
+    } catch (e) {
+        console.warn("could not start a window drag:", e)
+        return false
+    }
+}
+
 /** The main display's size in points (CoreGraphics reports the scaled mode's logical size), or
  *  null off-macOS / on failure. Used to clamp the initial window so it cannot open larger than
  *  the screen — the fixed default overflowed smaller displays, cutting off the bottom of every

--- a/desktop/main.ts
+++ b/desktop/main.ts
@@ -11,7 +11,7 @@
 
 import { SpaceStationServer, type BootOptions } from "./boot.ts"
 import { serve_ui } from "./splash.ts"
-import { extend_under_titlebar, main_screen_size, set_app_appearance } from "./macos_titlebar.ts"
+import { begin_window_drag, extend_under_titlebar, main_screen_size, set_app_appearance } from "./macos_titlebar.ts"
 import { has_plain_julia, julia_catalog, juliaup_info, load_settings, save_settings } from "./julia.ts"
 
 // Deno.BrowserWindow only exists inside the desktop runtime host. Fail with a hint, not a crash,
@@ -122,6 +122,7 @@ serve_ui({
         save_settings({ color_scheme: scheme })
         set_app_appearance(scheme)
     },
+    on_drag: () => void begin_window_drag(),
 })
 
 let closing = false

--- a/desktop/splash.ts
+++ b/desktop/splash.ts
@@ -43,6 +43,12 @@ ${base_css}
         <a id="pick" href="/launch?change=1">choose a different Julia version…</a>
     </div>
     <script>
+        // WKWebView has no CSS drag regions — mousedown here asks the shell to start a native
+        // window drag (AppKit tracks it from there)
+        document.querySelector(".dragbar").addEventListener("mousedown", (e) => {
+            if (e.button === 0) fetch("./api/drag", { method: "POST" }).catch(() => {})
+        })
+
         const tick = async () => {
             try {
                 const s = await (await fetch("./status")).json()
@@ -67,15 +73,21 @@ export interface UiHandlers {
     julia_info: () => Promise<unknown>
     on_launch: (opts: BootOptions & { remember?: boolean }) => Promise<void>
     on_appearance?: (scheme: "light" | "dark" | "system") => void
+    on_drag?: () => void
 }
 
-export const serve_ui = ({ state, julia_info, on_launch, on_appearance }: UiHandlers) =>
+export const serve_ui = ({ state, julia_info, on_launch, on_appearance, on_drag }: UiHandlers) =>
     Deno.serve(async (req) => {
         const path = new URL(req.url).pathname
         const json = (body: unknown) => new Response(JSON.stringify(body), { headers: { "content-type": "application/json" } })
         const page = (html: string) => new Response(html, { headers: { "content-type": "text/html; charset=utf-8" } })
         if (path === "/status") return json(state())
         if (path === "/api/julia") return json(await julia_info())
+        // fired on mousedown in a page's drag area: the shell starts a native window drag
+        if (path === "/api/drag" && req.method === "POST") {
+            on_drag?.()
+            return json({ ok: true })
+        }
         if (path === "/api/appearance" && req.method === "POST") {
             try {
                 const { scheme } = await req.json()

--- a/frontend/common/ColorScheme.js
+++ b/frontend/common/ColorScheme.js
@@ -63,14 +63,38 @@ const rewrite = (rule, scheme) => {
     if (rule.media.mediaText !== next) rule.media.mediaText = next
 }
 
+// WKWebView keeps drawing the page's scroller with its pre-flip state after a color-scheme
+// change — on a dark OS, forcing light left the notebook with no visible scrollbar at all.
+// Destroying and recreating the scroller is the reliable fix: hide the root's overflow for one
+// frame, then restore it along with the scroll position.
+const recreate_scrollbars = () => {
+    const de = document.documentElement
+    const x = window.scrollX
+    const y = window.scrollY
+    const prev = de.style.overflow
+    de.style.overflow = "hidden"
+    requestAnimationFrame(() => {
+        de.style.overflow = prev
+        window.scrollTo(x, y)
+    })
+}
+
+let last_applied = null
+
 const apply = (scheme) => {
     // The media rewrite below only governs AUTHOR styles — the UA still colors its own defaults
     // (default text, form controls, scrollbars) from the page's declared color-scheme and the OS.
     // With a dark OS and a forced-light page that meant white UA text on light backgrounds
     // (invisible buttons, washed-out logs). The color-scheme PROPERTY on :root overrides the
     // meta and pins the UA side too. (The desktop shell additionally flips the native window
-    // appearance to match, so WKWebView's own chrome — scrollbars included — follows along.)
+    // appearance to match, so WKWebView's own chrome follows along.)
     document.documentElement.style.colorScheme = scheme === "system" ? "" : scheme
+    // apply() re-runs constantly (new stylesheets arrive with cell output) — only nudge the
+    // scroller when the scheme actually changed, or it would flicker on every mutation.
+    if (last_applied !== scheme) {
+        last_applied = scheme
+        recreate_scrollbars()
+    }
     const walk_rules = (rules) => {
         for (const rule of rules) {
             if (rule.styleSheet != null) {


### PR DESCRIPTION
Two more places where WKWebView needs the shell's help (follow-ups to #44/#47 from on-device testing):

**Window still not movable.** `-webkit-app-region` is a Chromium/Electron feature — WKWebView ignores it entirely, so the deck strip was never draggable and #47's dragbar (same CSS) changed nothing: the window was resizable but not relocatable. The fix is the standard WKWebView-shell pattern: mousedown in a drag area (deck strip background — tabs excluded — or the shell pages' top strip) POSTs `/api/drag`, and the shell hands the in-flight mouse event to `NSWindow.performWindowDragWithEvent:` via the existing main-thread trampoline. AppKit then runs the entire native drag session (tracking, spaces, moving across displays). The NSEvent is retained and deliberately leaked (one per drag start) because it is read off-main; a nil event or window degrades to a no-op. **Verified by hand on the dev build: the window drags and moves between displays.**

**Notebook scrollbar still vanished on dark→light.** The appearance flip fixed the content, but WKWebView keeps drawing the page's *scroller* with its pre-flip state. `ColorScheme.js` now destroys and recreates the scroller — root overflow hidden for one frame, then restored with the scroll position — whenever the applied scheme actually changes (not on the constant stylesheet-mutation re-applies, so no flicker).

`deno check` clean; ColorScheme regression suite (compound-query preservation, round-trip restore) still passes in Playwright WebKit and Chrome.

## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/GroupTherapyOrg/SpaceStation.jl", rev="fix/native-window-drag-and-scroller")
julia> using SpaceStation
```
