### PR TITLE
fix: stop Pkg.Apps warning about PATH on every bootstrap

### DIFF
--- a/desktop/boot.ts
+++ b/desktop/boot.ts
@@ -228,7 +228,7 @@ export class SpaceStationServer {
                    # the app itself never depends on it.
                    try
                        Pkg.Apps.add(${spec})
-                       println("installed the spacestation CLI (add ~/.julia/bin to PATH to use it anywhere)")
+                       println("installed the spacestation CLI")
                    catch e
                        println("CLI install skipped: ", sprint(showerror, e))
                    end;
@@ -246,6 +246,11 @@ export class SpaceStationServer {
                 // the hub reads this via /api/v1/config: one webview window, so open workspaces
                 // in-place instead of spawning browser tabs
                 SPACESTATION_DESKTOP: "1",
+                // GUI-launched processes get the minimal system PATH, not the user's shell PATH
+                // (where ensure_cli_on_path put ~/.julia/bin) — so Pkg.Apps warned "not available
+                // in PATH" on every bootstrap even though the CLI was fully set up. Give the
+                // child the entry; notebooks that shell out see the CLI too.
+                PATH: `${home_dir()}/.julia/bin${Deno.build.os === "windows" ? ";" : ":"}${Deno.env.get("PATH") ?? ""}`,
                 ...(managed ? { SPACESTATION_DESKTOP_ENV: project } : {}),
             },
             stdout: "piped",


### PR DESCRIPTION
The v0.4.5 first-boot log showed Julia's Pkg.Apps warning *"App 'spacestation' was installed but is not available in PATH"* — even though the CLI setup is actually complete (`ensure_cli_on_path` had already added `~/.julia/bin` to the shell rc, verified present in `~/.zshrc`, shim installed).

The warning fires because GUI-launched processes carry the minimal system PATH, not the user's shell PATH — so the Julia process the app spawns for the managed bootstrap can't see the entry, and Pkg.Apps re-warns on every version bump (each one re-runs `Pkg.Apps.add`). Our own log line then repeated stale "add it yourself" advice on top.

Fix: the spawned server process gets `~/.julia/bin` prepended to its PATH (merge with parent env, `;` on Windows), so the warning has nothing to fire on — and notebooks that shell out can reach the `spacestation` CLI as a bonus. The log line now just says the CLI was installed; `ensure_cli_on_path` still prints its own "open a new terminal" note only when it actually adds something.

## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/GroupTherapyOrg/SpaceStation.jl", rev="fix/pkg-apps-path-warning")
julia> using SpaceStation
```
