### PR TITLE
fix: shift the deck tabs in fullscreen, and show a pointer cursor on tabs

### DIFF
--- a/desktop/deck.ts
+++ b/desktop/deck.ts
@@ -22,11 +22,14 @@ export const deck_html = (launcher_url: string) => /* html */ `<!doctype html>
         padding: 0 8px 0 10px; background: #0f0d16; -webkit-app-region: drag; user-select: none;
     }
     /* 28px = the native title bar height, so the tab pills center on the traffic lights' row */
-    body.inset #strip { height: 28px; padding: 3px 8px 3px 84px; }
+    body.inset #strip { height: 28px; padding: 3px 8px 3px 84px; transition: padding-left 0.12s ease-out; }
+    /* fullscreen hides the traffic lights, so the gap reserved for them would just be dead
+       space — reclaim it and let the tabs sit where every other row starts */
+    body.inset.fullscreen #strip { padding-left: 10px; }
     body.inset .tab { border-radius: 6px; }
     .tab {
         -webkit-app-region: no-drag; display: flex; align-items: center; gap: 0.45rem; max-width: 15rem;
-        padding: 0 0.65rem; border-radius: 7px 7px 0 0; color: #9a93b8; font-size: 12.5px; cursor: default;
+        padding: 0 0.65rem; border-radius: 7px 7px 0 0; color: #9a93b8; font-size: 12.5px; cursor: pointer;
         white-space: nowrap; overflow: hidden;
     }
     .tab .title { overflow: hidden; text-overflow: ellipsis; }
@@ -56,6 +59,24 @@ export const deck_html = (launcher_url: string) => /* html */ `<!doctype html>
         strip.addEventListener("mousedown", (e) => {
             if (e.button === 0 && e.target.closest(".tab") == null) fetch("./api/drag", { method: "POST" }).catch(() => {})
         })
+
+        // Entering/leaving fullscreen always resizes the window, so ask the shell then (rather
+        // than polling): it reads the window's own NSWindowStyleMaskFullScreen bit. Geometry
+        // heuristics were tried for this and lost to notch/menu-bar edge cases. Non-macOS shells
+        // answer false and the inset layout never applies there anyway.
+        const sync_fullscreen = async () => {
+            try {
+                const s = await (await fetch("./api/window")).json()
+                document.body.classList.toggle("fullscreen", s.fullscreen === true)
+            } catch {}
+        }
+        let fs_timer = null
+        addEventListener("resize", () => {
+            clearTimeout(fs_timer)
+            // after the transition animation settles, so we read the final state once
+            fs_timer = setTimeout(sync_fullscreen, 150)
+        })
+        sync_fullscreen()
         // NOTE: no fullscreen special-casing, deliberately. Auto-hiding the strip in sync with the
         // native fullscreen overlay was tried and looked broken more ways than it looked native
         // (notch geometry, the overlay stealing the mouse, unrelated helper windows). The strip is

--- a/desktop/macos_titlebar.ts
+++ b/desktop/macos_titlebar.ts
@@ -106,6 +106,25 @@ export const set_app_appearance = (scheme: "light" | "dark" | "system"): boolean
     }
 }
 
+/** Is the app's window in native fullscreen? (NSWindowStyleMaskFullScreen, 1 << 14.) The deck
+ *  asks so it can drop the gap it reserves for the traffic lights, which macOS hides in
+ *  fullscreen. False off-macOS — no other platform insets the strip in the first place.
+ *
+ *  NOTE: this reads the WINDOW'S OWN style bit, which is exactly what it claims to be. The
+ *  fullscreen tracking removed earlier tried to detect the auto-hiding titlebar OVERLAY by
+ *  geometry, which is what proved unreliable; nothing here depends on the overlay. */
+export const is_fullscreen = (): boolean => {
+    try {
+        let full = false
+        each_titled_window((_S, _w, mask) => {
+            if ((mask & 0x4000n) !== 0n) full = true
+        })
+        return full
+    } catch {
+        return false
+    }
+}
+
 /** Start a native window drag. WKWebView swallows every mouse event, so CSS app-region does
  *  nothing in this shell (it is a Chromium feature) and the window had NO way to be moved.
  *  The standard WKWebView-shell workaround: on mousedown in a page's drag area, the page calls

--- a/desktop/main.ts
+++ b/desktop/main.ts
@@ -11,7 +11,7 @@
 
 import { SpaceStationServer, type BootOptions } from "./boot.ts"
 import { serve_ui } from "./splash.ts"
-import { begin_window_drag, extend_under_titlebar, main_screen_size, set_app_appearance } from "./macos_titlebar.ts"
+import { begin_window_drag, extend_under_titlebar, is_fullscreen, main_screen_size, set_app_appearance } from "./macos_titlebar.ts"
 import { has_plain_julia, julia_catalog, juliaup_info, load_settings, save_settings } from "./julia.ts"
 
 // Deno.BrowserWindow only exists inside the desktop runtime host. Fail with a hint, not a crash,
@@ -123,6 +123,7 @@ serve_ui({
         set_app_appearance(scheme)
     },
     on_drag: () => void begin_window_drag(),
+    window_state: () => ({ fullscreen: is_fullscreen() }),
 })
 
 let closing = false

--- a/desktop/splash.ts
+++ b/desktop/splash.ts
@@ -74,9 +74,10 @@ export interface UiHandlers {
     on_launch: (opts: BootOptions & { remember?: boolean }) => Promise<void>
     on_appearance?: (scheme: "light" | "dark" | "system") => void
     on_drag?: () => void
+    window_state?: () => { fullscreen: boolean }
 }
 
-export const serve_ui = ({ state, julia_info, on_launch, on_appearance, on_drag }: UiHandlers) =>
+export const serve_ui = ({ state, julia_info, on_launch, on_appearance, on_drag, window_state }: UiHandlers) =>
     Deno.serve(async (req) => {
         const path = new URL(req.url).pathname
         const json = (body: unknown) => new Response(JSON.stringify(body), { headers: { "content-type": "application/json" } })
@@ -88,6 +89,9 @@ export const serve_ui = ({ state, julia_info, on_launch, on_appearance, on_drag 
             on_drag?.()
             return json({ ok: true })
         }
+        // the deck asks after every resize: fullscreen hides the traffic lights, so the strip
+        // drops the gap it reserves for them
+        if (path === "/api/window") return json(window_state?.() ?? { fullscreen: false })
         if (path === "/api/appearance" && req.method === "POST") {
             try {
                 const { scheme } = await req.json()


### PR DESCRIPTION
Two small deck-chrome fixes.

**Tabs stranded behind an empty gap in fullscreen.** The inset strip reserves 84px on the left for the traffic lights — but macOS hides them in fullscreen, so that gap became dead space and the tabs looked offset. The deck now asks the shell (`GET /api/window`) for the window's own `NSWindowStyleMaskFullScreen` bit after each resize (entering/leaving fullscreen always resizes, so no polling) and collapses the gap to the normal 10px, with a short transition.

This reads the *window's own style bit*, which is not the geometry-based auto-hiding-overlay detection that was tried and deliberately removed earlier — nothing here depends on the overlay, and the strip still stays put rather than hiding. Non-macOS shells answer `false` and never use the inset layout in the first place, so Windows/Linux are unaffected.

**Tabs showed the default arrow cursor** despite being clickable. They now use `cursor: pointer`, matching their close buttons — cross-platform, pure CSS.

Verified locally against the dev build, not just in a stub: `/api/window` returns `{"fullscreen":false}` windowed and `{"fullscreen":true}` once the real window is put in native fullscreen (toggled by exact PID). In WebKit the strip's padding-left goes 84px → 10px → 84px across the transition, tab left edge follows 84 → 10 → 84, and the tab cursor is `pointer` in every state.

## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/GroupTherapyOrg/SpaceStation.jl", rev="fix/fullscreen-tabs-and-cursor")
julia> using SpaceStation
```
