### PR TITLE
fix: upgrade xterm.js to 6.0.0 for the desktop app's caps-typing corruption

### DIFF
--- a/frontend/land.html
+++ b/frontend/land.html
@@ -17,7 +17,10 @@
 
     <link rel="stylesheet" href="themes/light.css">
     <link rel="stylesheet" href="themes/dark.css">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/css/xterm.min.css">
+    <!-- MUST match the @xterm/xterm version land.js imports from esm.sh: 6.0 rewrote the viewport
+         (VS Code-style scrollable element) and its styles moved with it — 5.5 CSS on a 6.0 DOM leaves
+         the scrollbar and selection layers unstyled. -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@xterm/xterm@6.0.0/css/xterm.min.css">
     <link rel="stylesheet" href="land.css">
 
     <script src="land.js" type="module" defer></script>

--- a/frontend/land.js
+++ b/frontend/land.js
@@ -784,8 +784,12 @@ const TerminalView = ({ tid, cwd, visible, scheme }) => {
             // _afterResize re-syncs the viewport — which is why dragging the panel width "fixed" a
             // broken tab); an unchanged-size reveal repaired nothing. So repair here: put the view
             // back where it was when the tab was hidden, then force the scroll geometry to re-sync.
-            // (viewport.syncScrollArea is internal API, but the xterm import is pinned to 5.5.0 —
-            // and FitAddon itself reaches through _core the same way.)
+            // (viewport.syncScrollArea was internal API and is GONE in xterm 6.0 — the viewport was
+            // rewritten around VS Code's scrollable element, which tracks scroll state internally
+            // instead of trusting the browser element's scrollTop. That internal tracking is exactly
+            // what the display:none scroll loss needed, so the repair below may simply be a no-op on
+            // 6.0; the optional chain keeps it harmless either way, and scrollToBottom/scrollLines
+            // are public API.)
             const term = term_ref.current
             if (term == null) return
             try {
@@ -824,8 +828,12 @@ const TerminalView = ({ tid, cwd, visible, scheme }) => {
         started.current = true
         ;(async () => {
             const [{ Terminal }, { FitAddon }, config] = await Promise.all([
-                import("https://esm.sh/@xterm/xterm@5.5.0?target=es2020"),
-                import("https://esm.sh/@xterm/addon-fit@0.10.0?target=es2020"),
+                // 6.0.0, not 5.5.0: 5.5 predates two upstream fixes that hit the desktop app directly —
+                // "Fixed CapsLock triggering input twice in MacOS" (#5282) and "Fix duplicate input for
+                // some IMEs" (#5024). The desktop shell is WKWebView (WebKit), where xterm 5.5's input
+                // layer garbles caps/fast typing into TUIs like Claude Code; Chrome never showed it.
+                import("https://esm.sh/@xterm/xterm@6.0.0?target=es2020"),
+                import("https://esm.sh/@xterm/addon-fit@0.11.0?target=es2020"),
                 get_json("./api/v1/config").catch(() => null),
             ])
             const term = new Terminal({


### PR DESCRIPTION
## The bug

Typing in caps in the integrated terminal (Claude Code chat) in the **desktop app** garbles the input box — duplicated words, cut-offs, injected runs of spaces. The browser (Chrome) never shows it.

## Why desktop-only

The desktop shell is **WKWebView — WebKit**. This isn't a desktop-code bug; it's an engine one. xterm.js 5.5.0 (our pin) has known WebKit input defects, and 6.0.0 ships fixes for exactly this symptom class:

- [xterm.js #5282](https://github.com/xtermjs/xterm.js/pull/5282): *"Fixed CapsLock triggering input twice in MacOS"*
- [xterm.js #5024](https://github.com/xtermjs/xterm.js/pull/5024): *"Fix duplicate input for some IMEs"*

Claude Code's Ink-style input box redraws its entire wrapped line per keystroke, so one doubled/dropped keystroke doesn't misprint a character — it desyncs the redraw and interleaves fragments of the previous frame with the current one ([anthropics/claude-code#23891](https://github.com/anthropics/claude-code/issues/23891) is the same amplification in other terminals).

## The change

- `land.js`: `@xterm/xterm` 5.5.0 → **6.0.0**, `@xterm/addon-fit` 0.10.0 → **0.11.0**
- `land.html`: the **separately-pinned CSS** moves in lockstep (6.0 rebuilt the viewport around VS Code's scrollable element; 5.5 CSS on a 6.0 DOM leaves scrollbar/selection layers unstyled) — the pairing is now called out in comments on both pins

Every 6.0 breaking change was checked against TerminalView's touchpoints: removed options (`windowsMode`, canvas renderer, `overviewRulerWidth`) are unused; `windowsPty` and `attachCustomKeyEventHandler` survive (verified in the shipped 6.0 bundle). The one casualty is internal `viewport.syncScrollArea` used by the hide/reveal scroll repair — already optional-chained, so it degrades to a no-op, and 6.0's viewport tracks scroll state internally rather than trusting the browser element's `scrollTop`, which is the exact failure that repair papered over.

## Validation

Local browser E2E is broken by Node 25 (control-tested: the existing terminal test fails identically on stock 5.5.0), so CI is the validator — the frontend suite includes the terminal paste + reattach-on-refresh tests, plus the Safari/WebKit leg. Final confirmation of the caps-typing fix needs the desktop app itself on the next release.

## If caps typing still corrupts after this

Two WebKit input bugs remain **open** upstream: [xterm.js #5374](https://github.com/xtermjs/xterm.js/issues/5374) (shifted/overlapping keys in Safari) and [xterm.js #5894](https://github.com/xtermjs/xterm.js/issues/5894) (WKWebView dead-key mangling). The next step would be a host-side key-normalization addon (the #5894 reporter ships one), not another version bump.

## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/GroupTherapyOrg/SpaceStation.jl", rev="fix/terminal-webkit-input")
julia> using SpaceStation
```
