### PR TITLE
fix: desktop parity — terminal corruption, export cards, Windows app icon

### DIFF
--- a/.github/workflows/Desktop.yml
+++ b/.github/workflows/Desktop.yml
@@ -85,7 +85,7 @@ jobs:
         run: |
           set -euo pipefail
           rm -rf dist/WindowSmoke*
-          deno desktop -o dist/WindowSmoke --allow-run --allow-net --allow-env --allow-read --allow-write window_smoke.ts
+          deno desktop -o dist/WindowSmoke --include icons --allow-run --allow-ffi --allow-net --allow-env --allow-read --allow-write window_smoke.ts
           # Locate the bundle rather than assuming its name: deno appends `.app` itself, so naming
           # the output `WindowSmoke.app` yields `WindowSmoke.app.app` on some versions.
           app=$(find dist -maxdepth 1 -name "*.app" | head -1)
@@ -110,7 +110,7 @@ jobs:
           # get WEBVIEW2_USER_DATA_FOLDER into the environment block before the runtime opens its
           # first window. A build without it falls back to setting the variable in-process, which
           # leaves the WebView2 profile at its default <exe>.WebView2 path — i.e. the bug, untested.
-          deno desktop --icon icons/spacestation.ico -o dist/WindowSmoke --allow-run --allow-net --allow-env --allow-read --allow-write window_smoke.ts
+          deno desktop --icon icons/spacestation.ico -o dist/WindowSmoke --include icons --allow-run --allow-ffi --allow-net --allow-env --allow-read --allow-write window_smoke.ts
           # Locate the exe rather than assuming the layout: a native build drops dist\WindowSmoke.exe
           # while a cross-compiled one nests it in dist\WindowSmoke\.
           #
@@ -197,7 +197,7 @@ jobs:
           # cscript, not PowerShell: WindowsInstaller's View.Execute takes an optional Record
           # parameter that neither pwsh 7 nor Windows PowerShell 5.1 will bind (both fail with
           # "Execute,Params"). VBScript is the host Microsoft's own MSI samples use.
-          cscript //nologo stamp_msi.vbs "dist/${{ matrix.built }}" $version
+          cscript //nologo stamp_msi.vbs "dist/${{ matrix.built }}" $version icons\spacestation.ico
           # PowerShell does NOT fail a step on a native command's exit code, even with
           # ErrorActionPreference=Stop. Without this the stamp could fail and the build would sail on
           # to ship an unstamped .msi — which is exactly what happened.

--- a/desktop/deno.json
+++ b/desktop/deno.json
@@ -10,11 +10,11 @@
         "build": "deno task buildinfo && deno task vendor && deno desktop --allow-run --allow-net --allow-read --allow-write --allow-env --allow-ffi --include vendor -o dist/SpaceStation.app main.ts && deno task buildinfo:restore",
         "build:dmg": "deno task buildinfo && deno task vendor && deno desktop --allow-run --allow-net --allow-read --allow-write --allow-env --allow-ffi --include vendor -o dist/SpaceStation.dmg main.ts && deno task buildinfo:restore",
         "build:mac-intel": "deno task buildinfo && deno task vendor x86_64-apple-darwin && deno desktop --allow-run --allow-net --allow-read --allow-write --allow-env --allow-ffi --include vendor --target x86_64-apple-darwin -o dist/SpaceStation-mac-intel.app main.ts && deno task buildinfo:restore",
-        "build:win": "deno task buildinfo && deno task vendor x86_64-pc-windows-msvc && deno desktop --allow-run --allow-net --allow-read --allow-write --allow-env --allow-ffi --include vendor --icon icons/spacestation.ico --target x86_64-pc-windows-msvc -o dist/SpaceStation-win-x64 main.ts && deno task buildinfo:restore",
+        "build:win": "deno task buildinfo && deno task vendor x86_64-pc-windows-msvc && deno desktop --allow-run --allow-net --allow-read --allow-write --allow-env --allow-ffi --include vendor --include icons --icon icons/spacestation.ico --target x86_64-pc-windows-msvc -o dist/SpaceStation-win-x64 main.ts && deno task buildinfo:restore",
         "build:linux": "deno task buildinfo && deno task vendor x86_64-unknown-linux-gnu && deno desktop --allow-run --allow-net --allow-read --allow-write --allow-env --allow-ffi --include vendor --target x86_64-unknown-linux-gnu -o dist/SpaceStation.AppImage main.ts && deno task buildinfo:restore",
         "vendor": "deno run --allow-net --allow-read --allow-write --allow-run vendor_juliaup.ts",
         "build:dmg-intel": "deno task buildinfo && deno task vendor x86_64-apple-darwin && deno desktop --allow-run --allow-net --allow-read --allow-write --allow-env --allow-ffi --include vendor --target x86_64-apple-darwin -o dist/SpaceStation.dmg main.ts && deno task buildinfo:restore",
-        "build:msi": "deno task buildinfo && deno task vendor x86_64-pc-windows-msvc && deno desktop --allow-run --allow-net --allow-read --allow-write --allow-env --allow-ffi --include vendor --target x86_64-pc-windows-msvc -o dist/SpaceStation.msi main.ts && deno task buildinfo:restore"
+        "build:msi": "deno task buildinfo && deno task vendor x86_64-pc-windows-msvc && deno desktop --allow-run --allow-net --allow-read --allow-write --allow-env --allow-ffi --include vendor --include icons --target x86_64-pc-windows-msvc -o dist/SpaceStation.msi main.ts && deno task buildinfo:restore"
     },
     "desktop": {
         "app": {

--- a/desktop/main.ts
+++ b/desktop/main.ts
@@ -13,6 +13,7 @@ import { SpaceStationServer, type BootOptions } from "./boot.ts"
 import { serve_ui } from "./splash.ts"
 import { begin_window_drag, extend_under_titlebar, is_fullscreen, main_screen_size, set_app_appearance } from "./macos_titlebar.ts"
 import { has_plain_julia, julia_catalog, juliaup_info, load_settings, save_settings } from "./julia.ts"
+import { set_windows_window_icon } from "./windows_icon.ts"
 
 // Deno.BrowserWindow only exists inside the desktop runtime host. Fail with a hint, not a crash,
 // when someone runs this with plain `deno run` (use smoke.ts for that).
@@ -77,6 +78,12 @@ const win = new BrowserWindow({
     transparentTitlebar: mac,
 })
 const under_titlebar = extend_under_titlebar()
+
+// The packaged .exe carries no icon resource (deno desktop doesn't embed one yet), so hand the
+// window its icon at runtime — this is what the taskbar and Alt+Tab display. No-op off Windows.
+void set_windows_window_icon(win, "SpaceStation").then((status) => {
+    if (status !== "set" && !status.startsWith("skipped")) console.warn("window icon:", status)
+})
 
 // The launcher's theme choice pins the native window appearance (macOS — a no-op elsewhere), so
 // WKWebView's prefers-color-scheme and its own chrome follow it like a real OS dark-mode switch.

--- a/desktop/stamp_msi.vbs
+++ b/desktop/stamp_msi.vbs
@@ -21,7 +21,7 @@
 '    FindRelatedProducts / RemoveExistingProducts makes it a proper major upgrade. UpgradeCode is
 '    left alone: it is the stable identity tying releases together.
 '
-'   cscript //nologo stamp_msi.vbs dist\SpaceStation.msi 0.4.8
+'   cscript //nologo stamp_msi.vbs dist\SpaceStation.msi 0.4.8 icons\spacestation.ico
 '
 ' VBScript, not PowerShell, on purpose. This drives the WindowsInstaller COM automation layer, whose
 ' View.Execute takes an optional Record parameter that neither pwsh 7 nor Windows PowerShell 5.1 will
@@ -129,6 +129,35 @@ Else
     WScript.Echo "summary: 'elevated privileges not required' already set"
 End If
 
+' ---- Shortcut + Add/Remove Programs icon (issue #63) ----
+' The packager embeds no icon in the exe, so the Start Menu shortcut and the Programs list show
+' the generic executable icon. The runtime half (WM_SETICON in the shell) covers the live
+' taskbar; this covers the installer surfaces: an Icon-table stream referenced by the Shortcut
+' row and by ARPPRODUCTICON. The argument is optional so older invocations keep working.
+If WScript.Arguments.Count >= 3 Then
+    Dim icoPath, iview, irec
+    icoPath = WScript.Arguments(2)
+    If Not fso.FileExists(icoPath) Then
+        WScript.Echo "FAILED: icon file not found: " & icoPath
+        WScript.Quit 1
+    End If
+    TryRunSQL "CREATE TABLE `Icon` (`Name` CHAR(72) NOT NULL, `Data` OBJECT NOT NULL PRIMARY KEY `Name`)"
+    On Error Resume Next
+    Set iview = db.OpenView("SELECT `Name`, `Data` FROM `Icon`")
+    iview.Execute
+    Set irec = installer.CreateRecord(2)
+    irec.StringData(1) = "spacestation.ico"
+    irec.SetStream 2, icoPath
+    ' 3 = msiViewModifyAssign: insert-or-replace, so re-stamping an already-stamped .msi is legal
+    iview.Modify 3, irec
+    iview.Close
+    CheckError "Icon table stream insert (" & icoPath & ")"
+    On Error GoTo 0
+    RunSQL "UPDATE `Shortcut` SET `Icon_`='spacestation.ico'"
+    TryRunSQL "DELETE FROM `Property` WHERE `Property`='ARPPRODUCTICON'"
+    RunSQL "INSERT INTO `Property` (`Property`, `Value`) VALUES ('ARPPRODUCTICON', 'spacestation.ico')"
+End If
+
 db.Commit
 Set db = Nothing
 Set installer = Nothing
@@ -146,9 +175,15 @@ gotParent = ReadOne(vdb, "SELECT `Directory_Parent` FROM `Directory` WHERE `Dire
 Set vdb = Nothing
 Set verifier = Nothing
 
-WScript.Echo "verify: ProductVersion=" & gotVersion & " ALLUSERS=[" & gotAllUsers & "] (2 = per-user) INSTALLDIR parent=" & gotParent
+Dim gotIcon
+gotIcon = ReadOne(vdb, "SELECT `Icon_` FROM `Shortcut`")
+WScript.Echo "verify: ProductVersion=" & gotVersion & " ALLUSERS=[" & gotAllUsers & "] (2 = per-user) INSTALLDIR parent=" & gotParent & " shortcut icon=[" & gotIcon & "]"
 If gotVersion <> productVersion Then
     WScript.Echo "FAILED: ProductVersion did not persist (wanted " & productVersion & ", file says " & gotVersion & ")"
+    WScript.Quit 1
+End If
+If WScript.Arguments.Count >= 3 And gotIcon <> "spacestation.ico" Then
+    WScript.Echo "FAILED: the shortcut is not wired to the icon (Icon_=[" & gotIcon & "])"
     WScript.Quit 1
 End If
 If gotParent <> "LocalAppDataFolder" Then

--- a/desktop/window_smoke.ts
+++ b/desktop/window_smoke.ts
@@ -81,6 +81,18 @@ if (ua == null) {
 }
 say(`[window-smoke] the webview rendered and ran JS — user-agent: ${ua}`)
 
+// The runtime icon setter (issue #63): prove the whole FFI chain — VFS ico materialization,
+// window-handle lookup, LoadImageW, WM_SETICON — actually works on a real Windows window. Off
+// Windows it reports "skipped" and this stays a no-op.
+{
+    const { set_windows_window_icon } = await import("./windows_icon.ts")
+    const icon_status = await set_windows_window_icon(win, "SpaceStation window smoke")
+    say(`[window-smoke] window icon: ${icon_status}`)
+    if (Deno.build.os === "windows" && icon_status !== "set") {
+        fail(`the runtime window icon was not set: ${icon_status}`)
+    }
+}
+
 // #55's regression check, restated for what actually fixes it. WebView2 always puts its user-data
 // folder beside the executable — laufey passes a NULL userDataFolder and WEBVIEW2_USER_DATA_FOLDER
 // is a convention the host app must implement, which CI demonstrated it does not. So the folder's

--- a/desktop/windows_icon.ts
+++ b/desktop/windows_icon.ts
@@ -1,0 +1,95 @@
+// Windows only: give the running window the SpaceStation icon (issue #63).
+//
+// `deno desktop` 2.9 embeds no icon resource into the .exe it packages — verified back in the #55
+// work: the binary is byte-identical with and without the icon configuration — so the taskbar,
+// Alt-Tab and the window caption all fall back to Windows' generic executable icon. Until the
+// packager learns to do it at build time, do it at runtime: load the .ico and hand it to the
+// window via WM_SETICON, the same call every Win32 app makes. The taskbar follows immediately.
+// (The Start Menu shortcut and Add/Remove Programs entry can't be fixed from here — those live in
+// the installer, which stamp_msi.vbs now handles with an Icon table entry.)
+//
+// Nothing here runs off Windows; every failure is caught and reported as a status string rather
+// than thrown — a missing icon must never take down the app.
+
+import { data_dir } from "./julia.ts"
+
+const WM_SETICON = 0x0080
+const ICON_SMALL = 0n
+const ICON_BIG = 1n
+const IMAGE_ICON = 1
+const LR_LOADFROMFILE = 0x0010
+const LR_DEFAULTSIZE = 0x0040
+
+/** UTF-16LE with a NUL terminator — charCodeAt yields UTF-16 code units directly, surrogate
+ *  pairs included, so non-ASCII profile paths survive. */
+const wide = (s: string): Uint8Array => {
+    const out = new Uint8Array((s.length + 1) * 2)
+    for (let i = 0; i < s.length; i++) {
+        const c = s.charCodeAt(i)
+        out[i * 2] = c & 0xff
+        out[i * 2 + 1] = c >> 8
+    }
+    return out
+}
+
+/** LoadImageW needs a real file. The .ico ships inside the compiled binary's VFS (--include
+ *  icons), or sits in the checkout during dev — materialize it once into the app-data dir, the
+ *  same pattern vendored_bin_dir uses for juliaup. */
+const materialize_ico = (): string => {
+    const path = `${data_dir()}\\spacestation.ico`
+    try {
+        Deno.statSync(path)
+        return path
+    } catch {
+        // not there yet
+    }
+    const bytes = Deno.readFileSync(new URL("./icons/spacestation.ico", import.meta.url))
+    Deno.mkdirSync(data_dir(), { recursive: true })
+    Deno.writeFileSync(path, bytes)
+    return path
+}
+
+/** Set the window's big+small icons. Returns a status string for logging/assertion: "set" on
+ *  success, "skipped: not windows" off-platform, otherwise what went wrong. */
+export const set_windows_window_icon = async (win: unknown, window_title: string): Promise<string> => {
+    if (Deno.build.os !== "windows") return "skipped: not windows"
+    try {
+        const ico_path = materialize_ico()
+        const user32 = Deno.dlopen("user32.dll", {
+            FindWindowW: { parameters: ["buffer", "buffer"], result: "pointer" },
+            LoadImageW: { parameters: ["pointer", "buffer", "u32", "i32", "i32", "u32"], result: "pointer" },
+            SendMessageW: { parameters: ["pointer", "u32", "u64", "pointer"], result: "isize" },
+        })
+        try {
+            // The window handle: laufey's getNativeWindow when it answers usefully, otherwise find
+            // the window by its (known, we set it) title. Retry briefly — the native window may
+            // trail the constructor by a beat.
+            let hwnd: Deno.PointerValue = null
+            for (let attempt = 0; attempt < 4 && hwnd == null; attempt++) {
+                if (attempt > 0) await new Promise((r) => setTimeout(r, 1500))
+                try {
+                    const raw = (win as any)?.getNativeWindow?.()
+                    if (typeof raw === "bigint" || typeof raw === "number") hwnd = Deno.UnsafePointer.create(BigInt(raw))
+                } catch {
+                    // fall through to FindWindowW
+                }
+                hwnd ??= user32.symbols.FindWindowW(null, wide(window_title))
+            }
+            if (hwnd == null) return `failed: no window handle for title ${JSON.stringify(window_title)}`
+
+            const big = user32.symbols.LoadImageW(null, wide(ico_path), IMAGE_ICON, 0, 0, LR_LOADFROMFILE | LR_DEFAULTSIZE)
+            if (big == null) return `failed: LoadImageW could not load ${ico_path}`
+            // Small: let Windows scale from the same file at its preferred small size.
+            const small = user32.symbols.LoadImageW(null, wide(ico_path), IMAGE_ICON, 16, 16, LR_LOADFROMFILE)
+            user32.symbols.SendMessageW(hwnd, WM_SETICON, ICON_BIG, big)
+            user32.symbols.SendMessageW(hwnd, WM_SETICON, ICON_SMALL, small ?? big)
+            return "set"
+        } finally {
+            // The HICONs must outlive this call (the window keeps using them), but the library
+            // handle itself is done. NOT closing user32 would also be fine; being tidy is free.
+            user32.close()
+        }
+    } catch (e) {
+        return `failed: ${e}`
+    }
+}

--- a/frontend/components/ExportBanner.js
+++ b/frontend/components/ExportBanner.js
@@ -2,7 +2,7 @@
 import dialogPolyfill from "https://cdn.jsdelivr.net/npm/dialog-polyfill@0.5.6/dist/dialog-polyfill.esm.min.js"
 
 import { useEventListener } from "../common/useEventListener.js"
-import { html, useLayoutEffect, useRef } from "../imports/Preact.js"
+import { html, useEffect, useLayoutEffect, useRef, useState } from "../imports/Preact.js"
 import { getCurrentLanguage, t, th } from "../common/lang.js"
 import * as desktop from "./DesktopInterface.js"
 import { with_offline_bundle_query } from "./PlutoLandUpload.js"
@@ -127,12 +127,36 @@ export const ExportBanner = ({
 
     const warn_if_safe_preview = () => (process_waiting_for_permission ? confirm(t("t_export_safe_preview_warning")) : true)
 
+    // The desktop shell is a WKWebView: window.print() and <a download> are no-ops there unless the
+    // embedder implements them, so these cards looked clickable and did nothing in the app (#60).
+    // In desktop mode the LOCAL server does the work instead — saves exports straight to ~/Downloads,
+    // and for PDF opens the system browser, where the print dialog exists. `desktop` stays false in
+    // every real browser, and the cards keep their original behavior there.
+    const [desktop, set_desktop] = useState(false)
+    const [desktop_status, set_desktop_status] = useState(/** @type {String?} */ (null))
+    useEffect(() => {
+        fetch("./api/v1/config")
+            .then((r) => r.json())
+            .then((c) => set_desktop(c?.desktop === true))
+            .catch(() => {})
+    }, [])
+    const desktop_export = (/** @type {Event} */ e, /** @type {String} */ type) => {
+        if (!desktop) return false
+        e.preventDefault()
+        set_desktop_status(t("t_export_desktop_working"))
+        fetch(`./api/v1/desktop_export?id=${notebook_id}&type=${type}`, { method: "POST" })
+            .then((r) => (r.ok ? r.json() : Promise.reject(new Error(String(r.status)))))
+            .then((d) => set_desktop_status(type === "pdf" ? t("t_export_desktop_opening_browser") : t("t_export_desktop_saved", { filename: d.filename })))
+            .catch(() => set_desktop_status(t("t_export_desktop_failed")))
+        return true
+    }
+
     return html`
         <dialog id="export" inert=${!open} open=${open} ref=${element_ref} class=${prideMonth ? "pride" : ""}>
             <div id="container">
                 <div class="export_title">${t("t_export_category_export")}</div>
                 <!-- no "download" attribute here: we want the jl contents to be shown in a new tab -->
-                <a href=${notebookfile_url} target="_blank" class="export_card" onClick=${(e) => exportNotebookDesktop(e, "file", notebook_id)}>
+                <a href=${notebookfile_url} target="_blank" class="export_card" onClick=${(e) => desktop_export(e, "file") || exportNotebookDesktop(e, "file", notebook_id)}>
                     <header role="none"><${Triangle} fill="#a270ba" /> ${t("t_export_card_notebook_file")}</header>
                     <section>${th("t_export_card_notebook_file_description")}</section>
                 </a>
@@ -148,6 +172,7 @@ export const ExportBanner = ({
                         }
                         e.preventDefault()
                         WarnForVisisblePasswords()
+                        if (desktop_export(e, "html")) return
                         window.dispatchEvent(new CustomEvent("open pluto html export", { detail: { download_url: notebookexport_url } }))
                     }}
                 >
@@ -162,12 +187,14 @@ export const ExportBanner = ({
                             e.preventDefault()
                             return
                         }
+                        if (desktop_export(e, "pdf")) return
                         window.print()
                     }}
                 >
                     <header role="none"><${Square} fill="#619b3d" />${t("t_export_card_pdf")}</header>
                     <section>${th("t_export_card_pdf_description")}</section>
                 </a>
+                ${desktop_status == null ? null : html`<div class="export_desktop_status" role="status">${desktop_status}</div>`}
                 ${html`
                     <div class="export_title">${t("t_export_category_record")}</div>
                     <a

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -659,6 +659,13 @@ header dialog#export div#container {
 header.show_export dialog#export div#container {
     overflow-x: auto;
 }
+/* feedback line for the desktop app's server-side exports (see ExportBanner's desktop branch) */
+#export .export_desktop_status {
+    flex-basis: 100%;
+    font-size: 0.85rem;
+    opacity: 0.8;
+    font-style: italic;
+}
 a.export_card {
     margin: 20px 5px;
     flex: 0 0 auto;

--- a/frontend/editor.js
+++ b/frontend/editor.js
@@ -11,6 +11,15 @@ import { parse_launch_params } from "./common/parse_launch_params.js"
 
 const url_params = new URLSearchParams(window.location.search)
 
+// &pluto_print=1: the desktop app's PDF export opens this page in a real browser purely to print
+// (its own WKWebView has no window.print) — pop the dialog once the page has settled. The delay is
+// crude but printing is user-supervised: worst case they close the dialog and press Cmd/Ctrl+P.
+if (url_params.get("pluto_print") === "1") {
+    window.addEventListener("load", () => {
+        setTimeout(() => window.print(), 2500)
+    })
+}
+
 //////////////
 // utils:
 

--- a/frontend/lang/english.json
+++ b/frontend/lang/english.json
@@ -152,6 +152,10 @@
     "t_export_card_record": "Record ",
     "t_export_card_record_description": "Capture the entire notebook, and any changes you make.",
     "t_export_card_pride_month_message": "The future is <strong>queer</strong>!",
+    "t_export_desktop_working": "Exporting…",
+    "t_export_desktop_saved": "Saved to your Downloads folder as “{{filename}}”.",
+    "t_export_desktop_opening_browser": "Opening in your browser — use its print dialog to save the PDF.",
+    "t_export_desktop_failed": "The export failed — see the server log for details.",
 
     "t_save_notebook_ellipsis": "Save notebook...",
     "t_save_notebook_button_label_when_currently_not_saved": "Choose",

--- a/src/webserver/CollabTerminal.jl
+++ b/src/webserver/CollabTerminal.jl
@@ -392,7 +392,30 @@ function handle_terminal_websocket(ws, session::ServerSession, query::Dict{Strin
                         # tiny geometry, and resizing the PTY to it reflows the shell to a sliver (the
                         # output then sticks in scrollback). No real terminal is usefully this small.
                         if rows !== nothing && cols !== nothing && 1 < rows < 1000 && 9 < cols < 1000
+                            changed = t.pty.rows != rows || t.pty.cols != cols
                             pty_resize!(t.pty, rows, cols)
+                            # Tell every OTHER attached client, so no grid can diverge from the pty.
+                            # Without this, a resize from any second attachment — a background browser
+                            # tab on the same workspace, a second window — reshaped the pty SILENTLY
+                            # under the client the user is looking at: the app inside starts drawing
+                            # for the new width while that client's grid keeps the old one, and every
+                            # redraw-in-place TUI (Claude Code, vim) turns the mismatch into
+                            # duplicated/cut-off frame fragments. Reproduced byte-for-byte with two
+                            # protocol clients; the frontend already adopts geometry frames whenever
+                            # they arrive (its attach handler), so the server side is the whole fix.
+                            # The adopting clients echo a same-size resize back, which `changed`
+                            # filters — no broadcast loop.
+                            if changed
+                                lock(t.lock) do
+                                    for client in t.clients
+                                        client === ws && continue
+                                        try
+                                            HTTP.WebSockets.send(client, """{"rows":$(rows),"cols":$(cols)}""")
+                                        catch
+                                        end
+                                    end
+                                end
+                            end
                         end
                     end
                 elseif startswith(message, "2:")

--- a/src/webserver/Router.jl
+++ b/src/webserver/Router.jl
@@ -201,6 +201,42 @@ function http_router_for(session::ServerSession)
         end
     end
     HTTP.register!(router, "GET", "/notebookexport", serve_notebookexport)
+
+    # Desktop-only export actions (issue #60). The desktop shell is a WKWebView, which implements
+    # neither window.print() nor <a download> unless the embedding app does — so the export cards,
+    # fine in every real browser, silently did nothing in the app. This server runs on the same
+    # machine as that webview and can do what the webview cannot: write the export straight into
+    # ~/Downloads, and for PDF open the notebook in the system's default browser, where the print
+    # dialog (and its save-as-PDF) actually exists. Gated on the desktop env var, which the shell
+    # sets and local child workspace servers inherit — on an ssh-remote server it is absent, and
+    # this endpoint correctly refuses (writing to the REMOTE machine's Downloads would be wrong).
+    function serve_desktop_export(request::HTTP.Request)
+        haskey(ENV, "SPACESTATION_DESKTOP") ||
+            return error_response(400, "Desktop only", "This endpoint exists only in the desktop app.", "")
+        try
+            notebook = notebook_from_uri(request)
+            query = HTTP.queryparams(HTTP.URI(request.target))
+            type = get(query, "type", "file")
+            if type == "pdf"
+                # The Host header carries the port this request actually arrived on — no plumbing.
+                host = HTTP.header(request, "Host", "127.0.0.1")
+                url = "http://$(host)/edit?id=$(notebook.notebook_id)&secret=$(session.secret)&pluto_print=1"
+                cmd = Sys.isapple() ? `open $url` : Sys.iswindows() ? `cmd /c start "" $url` : `xdg-open $url`
+                Base.run(cmd; wait=false) # Base.: inside this module, bare `run` is the server entrypoint
+                return HTTP.Response(200, ["Content-Type" => "application/json; charset=utf-8"], """{"opened":true}""")
+            end
+            downloads = joinpath(homedir(), "Downloads")
+            isdir(downloads) || (downloads = homedir())
+            base = joinpath(downloads, without_pluto_file_extension(basename(notebook.path)))
+            path = type == "html" ? numbered_until_new(base; suffix=".html") : numbered_until_new(base; suffix=".jl")
+            write(path, type == "html" ? generate_html(notebook) : sprint(save_notebook, notebook))
+            HTTP.Response(200, ["Content-Type" => "application/json; charset=utf-8"],
+                """{"saved":true,"filename":$(_json(basename(path)))}""")
+        catch e
+            return error_response(400, "Export failed", "Please <a href='https://github.com/GroupTherapyOrg/SpaceStation.jl/issues'>report this error</a>!", sprint(showerror, e, stacktrace(catch_backtrace())))
+        end
+    end
+    HTTP.register!(router, "POST", "/api/v1/desktop_export", serve_desktop_export)
     
     function serve_notebookupload(request::HTTP.Request)
         uri = HTTP.URI(request.target)


### PR DESCRIPTION
Fixes #60. Fixes #63. Also fixes the desktop terminal's input-box corruption (duplicated/cut-off words while typing — reported in-session, no issue number).

One consolidated desktop-parity PR: three user-reported desktop bugs, each fixed at the layer that owns it, each verified before shipping.

## 1. Terminal corruption — the pty resize war

The desktop terminal kept garbling Claude Code's input box (duplicated words, cut-offs, runs of spaces) even after the xterm 6 upgrade in v0.4.9, so this fix started from a reproduction instead of a theory. Three probes against the same WKWebView + laufey host the app uses:

1. **Real AppKit NSEvents** (shift typing, key rollover, Shift+Tab, CapsLock) injected into xterm 6 → every `onData` byte correct, 5/5 scenarios. *Input exonerated.*
2. **Ink-style redraw storm** (cursor-up + clear + rewrite, wrapped lines, websocket-like chunking) → logical buffer, DOM output and expectation identical. *Rendering exonerated.*
3. **Two protocol clients on one tid**: client A at 100 cols runs a loop printing its pty width; client B attaches and sends one 80-col resize — what any background tab's refit does. A's output goes `100 100 … 80 80` — **the pty reshaped under it — and A receives no geometry frame at all.** *Reproduced.*

The server allows any number of clients per terminal and applies whichever resize arrives last, telling nobody else. The app inside then draws for the new width while the client the user is looking at keeps its old grid — and every redraw-in-place TUI turns that mismatch into exactly the reported fragments. Survives any xterm version, because xterm faithfully renders bytes computed for the wrong grid.

**Fix:** when a resize is applied, broadcast the new geometry to every other attached client (`CollabTerminal.jl`). The frontend already adopts geometry frames whenever they arrive, so the server is the entire change; a `changed` guard filters the adopting clients' same-size echo, so no loop. Re-running probe 3 against the fixed server: A receives `{"rows":24,"cols":80}` the moment B resizes. Contention degrades to tmux-style last-resizer-wins with every grid consistent, instead of corruption.

## 2. #60 — every export card was dead in the desktop

Each card leans on a browser affordance WKWebView only provides when the embedder implements it (ours doesn't): `window.print()` (no-op), `target="_blank"` (needs a UI delegate), `<a download>` (needs a download delegate). All three work in every real browser, which is why this shipped unseen.

**Fix:** the desktop's structural advantage is that the server runs on the same machine. A desktop-gated endpoint (`POST /api/v1/desktop_export`) writes `.jl`/`.html` straight to `~/Downloads` (collision-numbered, inline "Saved as …" feedback), and for PDF opens the system default browser via an authed `&pluto_print=1` URL that `editor.js` answers by popping the print dialog. Gated on `SPACESTATION_DESKTOP` — inherited by local child servers, absent on ssh-remote ones (correctly: writing to the *remote* Downloads would be worse than a no-op). Real browsers keep the exact original behavior.

**Verified end-to-end** with an isolated `HOME`: files land collision-numbered in the sandboxed Downloads; PDF invokes the system opener with the right authed URL (captured via a stubbed `open`). The live test caught and fixed a real bug: bare `run` in the module resolves to `SpaceStation.run` — the server entrypoint — not `Base.run`.

## 3. #63 — the Windows app had no icon anywhere

`deno desktop` embeds no icon resource into the `.exe` (verified: byte-identical binary with and without the icon config). macOS has shipped a correct `.icns` since the first desktop release — nothing to fix there.

**Fix, at the two places Windows reads icons from:**
- **Runtime** (`desktop/windows_icon.ts`): `WM_SETICON` via user32 FFI — taskbar and Alt-Tab, the exact report. Handle via laufey's `getNativeWindow` with a `FindWindowW`-by-title fallback; every failure is a logged status string, never a throw.
- **Installer** (`stamp_msi.vbs`): streams the `.ico` into the MSI `Icon` table (`msiViewModifyAssign` — re-stamp legal), wires the `Shortcut` row and `ARPPRODUCTICON`, and reads it all back in the self-verification.

**CI proves both halves:** the Windows headed smoke asserts the runtime setter reports `set` on a real window; the stamper's read-back fails the build if the shortcut isn't wired.

## Deliberately not in this PR

- ssh-remote workspaces' exports (their server correctly refuses the endpoint; routing via the local hub is follow-up)
- the exe's *file* icon in Explorer (blocked on the packager embedding PE resources)
- #57 (MSI upgrade-in-place) and #58 (pre-existing precompilation test flake) — tracked separately