### PR TITLE
feat: browser-style zoom in the desktop, and a working HTML export

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -88,7 +88,7 @@ HEADLESS=false PLUTO_PORT=2345 npm run test -- -t="suite name"  # one suite
 ### TypeScript check (matches CI `TypeScriptCheck.yml`)
 ```bash
 cd frontend && npm install
-tsc --noEmit --strictNullChecks false   # from repo root
+tsc --noEmit   # from repo root (CI runs full strict — no --strictNullChecks false)
 ```
 `tsconfig.json` has `allowJs` + `checkJs` — the frontend is plain JS with JSDoc type annotations, checked as TS.
 

--- a/frontend/common/Zoom.js
+++ b/frontend/common/Zoom.js
@@ -1,0 +1,133 @@
+// Browser-style zoom for the desktop app (issue #66). In a browser, Cmd/Ctrl+= / - / 0 and
+// pinch are chrome features; the desktop shell is a bare webview with no chrome, so none of it
+// existed there. This module recreates it the way Chrome behaves: the familiar zoom ladder,
+// remembered PER ORIGIN — which, since every workspace is its own origin, gives per-workspace
+// zoom for free, exactly like per-site zoom in a real browser.
+//
+// Desktop-only by a server signal, not by guesswork: /api/v1/config reports desktop:true when the
+// server was launched by the shell. In a real browser that's false and this module does nothing,
+// so the browser's own zoom keeps working without us double-zooming on top of it. (Pages CAN
+// preempt browser zoom via preventDefault — that is why gating matters.)
+//
+// Importing applies the stored zoom; the keyboard/trackpad wiring arms only in desktop mode.
+// Same-origin frames (the hub's editor iframes) stay in sync through `storage` events, the same
+// mechanism ColorScheme.js uses.
+
+const KEY = "spacestation zoom"
+// Chrome's ladder, for muscle-memory-compatible steps.
+const LADDER = [0.25, 1 / 3, 0.5, 2 / 3, 0.75, 0.8, 0.9, 1, 1.1, 1.25, 1.5, 1.75, 2, 2.5, 3, 4, 5]
+
+export const get_zoom = () => {
+    try {
+        const z = Number(localStorage.getItem(KEY))
+        return Number.isFinite(z) && z >= LADDER[0] && z <= LADDER[LADDER.length - 1] ? z : 1
+    } catch {
+        return 1
+    }
+}
+
+const apply = (z) => {
+    // Standard CSS `zoom` (WebKit has shipped it forever; standardized 2024): layout-affecting,
+    // so clientWidth changes and ResizeObservers fire — the terminal refits, CodeMirror reflows,
+    // exactly as they do under real browser zoom.
+    document.documentElement.style.zoom = z === 1 ? "" : String(z)
+}
+
+let indicator_timer = null
+const show_indicator = (z) => {
+    let el = document.getElementById("zoom-indicator")
+    if (el == null) {
+        el = document.createElement("div")
+        el.id = "zoom-indicator"
+        el.setAttribute("role", "status")
+        document.body.appendChild(el)
+    }
+    el.textContent = `${Math.round(z * 100)}%`
+    el.classList.add("visible")
+    clearTimeout(indicator_timer)
+    indicator_timer = setTimeout(() => el.classList.remove("visible"), 1200)
+}
+
+export const set_zoom = (z) => {
+    z = Math.min(LADDER[LADDER.length - 1], Math.max(LADDER[0], z))
+    try {
+        localStorage.setItem(KEY, String(z))
+    } catch {}
+    apply(z)
+    show_indicator(z)
+}
+
+const step = (direction) => {
+    const current = get_zoom()
+    // nearest ladder rung, then move one step — so continuous pinch and discrete keys interleave sanely
+    let i = 0
+    for (let j = 1; j < LADDER.length; j++) if (Math.abs(LADDER[j] - current) < Math.abs(LADDER[i] - current)) i = j
+    set_zoom(LADDER[Math.min(LADDER.length - 1, Math.max(0, i + direction))])
+}
+
+// Apply the stored zoom on load in every context (harmless at 1). The event wiring below is
+// desktop-gated; applying isn't, so a same-origin frame opened later starts at the right zoom
+// even before the config answer arrives.
+apply(get_zoom())
+
+window.addEventListener("storage", (e) => {
+    if (e.key === KEY) apply(get_zoom())
+})
+
+const arm = () => {
+    const mac = navigator.platform.toUpperCase().includes("MAC")
+    window.addEventListener(
+        "keydown",
+        (e) => {
+            const mod = mac ? e.metaKey && !e.ctrlKey : e.ctrlKey
+            if (!mod || e.altKey) return
+            // e.key varies with layout and shift ("=", "+", "±"); e.code names the physical key.
+            if (e.code === "Equal" || e.key === "+" || e.key === "=") {
+                e.preventDefault()
+                step(+1)
+            } else if (e.code === "Minus" || e.key === "-") {
+                e.preventDefault()
+                step(-1)
+            } else if (e.code === "Digit0" || e.key === "0") {
+                e.preventDefault()
+                set_zoom(1)
+            }
+        },
+        { capture: true }
+    )
+    // Ctrl+wheel is how Chromium delivers both the keyboard-modifier scroll AND trackpad pinch.
+    let wheel_accum = 0
+    window.addEventListener(
+        "wheel",
+        (e) => {
+            if (!e.ctrlKey) return
+            e.preventDefault()
+            wheel_accum += -e.deltaY
+            if (Math.abs(wheel_accum) > 30) {
+                step(wheel_accum > 0 ? +1 : -1)
+                wheel_accum = 0
+            }
+        },
+        { capture: true, passive: false }
+    )
+    // WebKit delivers trackpad pinch as proprietary gesture events (not ctrl+wheel like Chromium).
+    let gesture_base = 1
+    window.addEventListener("gesturestart", (e) => {
+        e.preventDefault()
+        gesture_base = get_zoom()
+    })
+    window.addEventListener("gesturechange", (e) => {
+        e.preventDefault()
+        // @ts-ignore — e.scale is the WebKit gesture event's own property
+        set_zoom(gesture_base * e.scale)
+    })
+    window.addEventListener("gestureend", (e) => e.preventDefault())
+}
+
+// Desktop only — see the header. The fetch is relative, so each origin asks its own server.
+fetch("./api/v1/config")
+    .then((r) => r.json())
+    .then((c) => {
+        if (c?.desktop === true) arm()
+    })
+    .catch(() => {})

--- a/frontend/common/Zoom.js
+++ b/frontend/common/Zoom.js
@@ -15,12 +15,14 @@
 
 const KEY = "spacestation zoom"
 // Chrome's ladder, for muscle-memory-compatible steps.
-const LADDER = [0.25, 1 / 3, 0.5, 2 / 3, 0.75, 0.8, 0.9, 1, 1.1, 1.25, 1.5, 1.75, 2, 2.5, 3, 4, 5]
+const MIN_ZOOM = 0.25
+const MAX_ZOOM = 5
+const LADDER = [MIN_ZOOM, 1 / 3, 0.5, 2 / 3, 0.75, 0.8, 0.9, 1, 1.1, 1.25, 1.5, 1.75, 2, 2.5, 3, 4, MAX_ZOOM]
 
 export const get_zoom = () => {
     try {
         const z = Number(localStorage.getItem(KEY))
-        return Number.isFinite(z) && z >= LADDER[0] && z <= LADDER[LADDER.length - 1] ? z : 1
+        return Number.isFinite(z) && z >= MIN_ZOOM && z <= MAX_ZOOM ? z : 1
     } catch {
         return 1
     }
@@ -49,7 +51,7 @@ const show_indicator = (z) => {
 }
 
 export const set_zoom = (z) => {
-    z = Math.min(LADDER[LADDER.length - 1], Math.max(LADDER[0], z))
+    z = Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, z))
     try {
         localStorage.setItem(KEY, String(z))
     } catch {}
@@ -60,9 +62,17 @@ export const set_zoom = (z) => {
 const step = (direction) => {
     const current = get_zoom()
     // nearest ladder rung, then move one step — so continuous pinch and discrete keys interleave sanely
-    let i = 0
-    for (let j = 1; j < LADDER.length; j++) if (Math.abs(LADDER[j] - current) < Math.abs(LADDER[i] - current)) i = j
-    set_zoom(LADDER[Math.min(LADDER.length - 1, Math.max(0, i + direction))])
+    let nearest = 0
+    let best = Infinity
+    LADDER.forEach((v, i) => {
+        const d = Math.abs(v - current)
+        if (d < best) {
+            best = d
+            nearest = i
+        }
+    })
+    const next = LADDER[Math.min(LADDER.length - 1, Math.max(0, nearest + direction))]
+    if (next !== undefined) set_zoom(next)
 }
 
 // Apply the stored zoom on load in every context (harmless at 1). The event wiring below is

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -4640,3 +4640,22 @@ jlerror.syntax-error > header {
     background: var(--black);
     color: var(--white);
 }
+
+/* the desktop zoom indicator (common/Zoom.js): a transient "120%" chip, browser-style */
+#zoom-indicator {
+    position: fixed;
+    top: 12px;
+    right: 12px;
+    z-index: 10000;
+    padding: 0.35rem 0.8rem;
+    border-radius: 8px;
+    background: rgba(20, 18, 28, 0.85);
+    color: #e8e4f5;
+    font: 600 0.9rem system-ui, sans-serif;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.15s ease-out;
+}
+#zoom-indicator.visible {
+    opacity: 1;
+}

--- a/frontend/editor.js
+++ b/frontend/editor.js
@@ -1,6 +1,7 @@
 import { html, render, useEffect, useRef, useState } from "./imports/Preact.js"
 import "./common/NodejsCompatibilityPolyfill.js"
 import "./common/ColorScheme.js" // applies the app-wide light/dark override + follows hub toggles live
+import "./common/Zoom.js" // browser-style zoom for the desktop app (no-op in real browsers)
 
 import { Editor, default_path } from "./components/Editor.js"
 import { FetchProgress, read_Uint8Array_with_progress } from "./components/FetchProgress.js"

--- a/frontend/land.css
+++ b/frontend/land.css
@@ -1568,3 +1568,22 @@ dialog.land-confirm button.go.danger {
         animation-duration: 2.4s;
     }
 }
+
+/* the desktop zoom indicator (common/Zoom.js): a transient "120%" chip, browser-style */
+#zoom-indicator {
+    position: fixed;
+    top: 12px;
+    right: 12px;
+    z-index: 10000;
+    padding: 0.35rem 0.8rem;
+    border-radius: 8px;
+    background: rgba(20, 18, 28, 0.85);
+    color: #e8e4f5;
+    font: 600 0.9rem system-ui, sans-serif;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.15s ease-out;
+}
+#zoom-indicator.visible {
+    opacity: 1;
+}

--- a/frontend/land.js
+++ b/frontend/land.js
@@ -16,6 +16,7 @@
 import { html, render, useState, useEffect, useCallback, useRef } from "./imports/Preact.js"
 import { pluto_file_extensions, has_pluto_file_extension } from "./common/PlutoFileExtensions.js"
 import { cycle_color_scheme, get_color_scheme, prefers_dark } from "./common/ColorScheme.js"
+import "./common/Zoom.js" // browser-style zoom for the desktop app (no-op in real browsers)
 
 const get_text = async (url, opts) => {
     const r = await fetch(url, opts)

--- a/src/notebook/Export.jl
+++ b/src/notebook/Export.jl
@@ -5,6 +5,13 @@ import URIs
 using MIMEs: mime_from_path
 const default_binder_url = "https://mybinder.org/v2/gh/fonsp/pluto-on-binder/v$(string(PLUTO_VERSION))"
 
+# This fork's assets live in this fork's repo. The roots below were upstream's
+# JuliaPluto/Pluto.jl, which has no tag for SpaceStation's version numbers — every asset in an
+# exported HTML 404'd and the file opened blank (issue #60, the reporter's follow-up). jsdelivr
+# serves any public GitHub repo at any tag, and this repo's frontend/ needs no build step, so
+# pointing the root here is the whole fix.
+const cdn_repo = "GroupTherapyOrg/SpaceStation.jl"
+
 const cdn_version_override = nothing
 # const cdn_version_override = "2a48ae2"
 
@@ -34,7 +41,7 @@ function cdnified_html(filename::AbstractString;
             try
                 original = read(project_relative_path(distdir, filename), String)
                 
-                cdn_root = "https://cdn.jsdelivr.net/gh/JuliaPluto/Pluto.jl@$(string(PLUTO_VERSION))/$(distdir)/"
+                cdn_root = "https://cdn.jsdelivr.net/gh/$(cdn_repo)@$(string(PLUTO_VERSION))/$(distdir)/"
 
                 @debug "Using CDN for Pluto assets:" cdn_root
 
@@ -67,7 +74,7 @@ function cdnified_html(filename::AbstractString;
         let
             original = read(project_relative_path("frontend", filename), String)
 
-            cdn_root = something(pluto_cdn_root, "https://cdn.jsdelivr.net/gh/JuliaPluto/Pluto.jl@$(something(cdn_version_override, string(something(version, PLUTO_VERSION))))/frontend/")
+            cdn_root = something(pluto_cdn_root, "https://cdn.jsdelivr.net/gh/$(cdn_repo)@$(something(cdn_version_override, string(something(version, PLUTO_VERSION))))/frontend/")
 
             @debug "Using CDN for Pluto assets:" cdn_root
             if offline_bundle

--- a/test/webserver.jl
+++ b/test/webserver.jl
@@ -192,8 +192,12 @@ end
     @test occursin(string(Pluto.PLUTO_VERSION), export_contents)
     @test occursin("</html>", export_contents)
     @test occursin("insertion-spot", export_contents)
-    # pluto.land needs to find this pattern:
-    plutoland_regex = r"href=\"(https://cdn\.jsdelivr\.net/gh/(?:fonsp|JuliaPluto)/Pluto\.jl@([\d.]+)/)[\w/.\\d\-]*\""
+    # The export's assets must come from THIS fork's repo: upstream has no tags for SpaceStation's
+    # versions, so the old (?:fonsp|JuliaPluto)/Pluto.jl root 404'd on every asset and exports
+    # opened blank (#60). This regex previously pinned that broken root — the test encoded the bug.
+    # (Upstream's comment here said pluto.land greps for its pattern; this fork's upload flow leans
+    # on the offline bundle, which embeds assets, so that concern does not transfer.)
+    plutoland_regex = r"href=\"(https://cdn\.jsdelivr\.net/gh/GroupTherapyOrg/SpaceStation\.jl@([\d.]+)/)[\w/.\\d\-]*\""
     @test occursin(plutoland_regex, export_contents)
     
     


### PR DESCRIPTION
Addresses #66. Addresses #60 (the remaining HTML-export half — deliberately *not* auto-closing either issue; the reporters confirm, per this repo's process).

## Zoom (#66)

In a browser, Cmd/Ctrl+`=` / `-` / `0` and pinch are chrome features; the desktop shell is a bare webview with no chrome, so none of it existed. `frontend/common/Zoom.js` recreates Chrome's behavior:

- the familiar **zoom ladder**, with a transient % chip as feedback
- **per-origin persistence** — every workspace is its own origin, so this is per-workspace zoom for free, exactly like per-site zoom in a real browser
- keyboard + Ctrl+wheel (Chromium's pinch delivery, for Windows) + WebKit gesture events (macOS trackpad pinch)
- applied via standard CSS `zoom` — layout-affecting, so ResizeObservers fire: the terminal refits, CodeMirror reflows, same as real browser zoom
- **desktop-gated by the server signal** (`config.desktop`), so in real browsers it stays inert and never double-zooms on top of the browser's own

**Verified** by posting real AppKit key events through a WKWebView at this exact module: `Cmd+=` ×2 → 1.25 (ladder), `Cmd+-` → 1.1, `Cmd+0` → reset, all persisted.

## HTML export opens blank (#60 follow-up)

The reporter confirmed `.jl` + PDF work and the saved HTML opens blank. Root cause: the export's asset roots were still upstream's `cdn.jsdelivr.net/gh/JuliaPluto/Pluto.jl@<version>/…`, and upstream has no tags for this fork's versions — every asset 404'd. Not desktop-specific: **any** HTML export from this fork was broken.

Fix: both CDN constructions now point at this fork's repo (jsdelivr serves any public repo at any tag; `frontend/` needs no build step). **Verified end to end**: assets return 200 from the fork CDN at a released tag, and a freshly exported notebook loaded in a WKWebView probe boots the editor and renders cells — while the pre-fix export in the same probe reproduces the reported blank page.

## Asking the reporters

Both issues stay open until @tknopp confirms on a released build.

## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/GroupTherapyOrg/SpaceStation.jl", rev="feat/zoom-and-html-export")
julia> using SpaceStation
```
