### PR TITLE
fix: zoom compensates the body, not main — no more proportional left border

### DIFF
--- a/frontend/common/Zoom.js
+++ b/frontend/common/Zoom.js
@@ -45,10 +45,14 @@ export const get_zoom = () => {
  *  viewport exactly like browser zoom, while the document scroller stays unzoomed and every
  *  scroll primitive keeps working. It also scopes tighter: the editor's own header stays 100%.
  */
-const zoom_target = () => document.querySelector("main") ?? document.documentElement
-
+// BODY, not <main>: main is a flex item with its own max-width and centering, and compensating a
+// capped, centered element re-centers the shrunken layout box and clips the visual overflow behind
+// body's overflow-x:hidden — v0.5.1 shipped exactly that (content shoved sideways, right side
+// unreachable). body has margin:0 and is the page container: compensated body reflows the whole
+// page to the viewport at every step, header included — which is precisely what browser zoom does
+// to a standalone notebook tab.
 const apply = (z) => {
-    const el = zoom_target()
+    const el = document.body
     if (!(el instanceof HTMLElement)) return
     el.style.zoom = z === 1 ? "" : String(z)
     el.style.width = z === 1 ? "" : `calc(100% / ${z})`


### PR DESCRIPTION
Addresses #66 — the v0.5.1 defect reported identically by the maintainer and @tknopp: *"when zooming in, a border on the left appears and moves everything to the right. The border is proportional to the zoom level."*

**Cause:** the width compensation sat on `<main>` — a flex item with its own `max-width` and centering. Shrinking its layout width re-centers the shrunken box inside an unzoomed container (an offset of exactly half the compensation: the proportional border), and the scaled overflow vanishes behind `body { overflow-x: hidden }`, so the right side is unreachable.

**Fix:** compensate `body` (margin 0, the actual page container). The whole page reflows to the viewport at every zoom step — what browser zoom does to a standalone notebook tab — and `main` lays out inside it exactly as it does unzoomed.

**Verified against the real editor page** (sample notebook on a desktop-mode dev server, injected key events) — the v0.5.1 bug had escaped a synthetic probe that lacked Pluto's actual `main` styling, so the harness now drives the genuine page:

| | baseline | 175% | reset |
|---|---|---|---|
| notebook left edge | 0px | **0px** (no border) | 0px |
| horizontal overflow | 0px | **0px** | 0px |

Stays open on #66 for reporter confirmation on the release.

## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/GroupTherapyOrg/SpaceStation.jl", rev="fix/zoom-body-target")
julia> using SpaceStation
```
