### PR TITLE
fix: never seed AGENTS.md/CLAUDE.md into fresh workspaces

### DIFF
--- a/src/AgentSurface.jl
+++ b/src/AgentSurface.jl
@@ -215,18 +215,64 @@ function ensure_agents_md(dir::AbstractString; files=("AGENTS.md", "CLAUDE.md"))
 end
 
 """
+    ensure_git_exclude(dir; files)
+
+Keep the seeded files out of `git status` without touching anything shareable: append them to
+`.git/info/exclude`, the repo-local, never-committed cousin of `.gitignore`. This is what makes
+opt-in seeding polite — the files exist for agents, and git treats them as invisible machine-local
+artifacts (issue #73: "Git wants to add and track them as soon as I open a project"). Best-effort:
+skipped when `dir` isn't a git repo, when `.git` is a worktree pointer file, or when the entries
+are already present (also honors an existing tracked file: exclude only affects untracked paths).
+"""
+function ensure_git_exclude(dir::AbstractString; files=("AGENTS.md", "CLAUDE.md"))
+    gitdir = joinpath(dir, ".git")
+    isdir(gitdir) || return  # not a repo, or a worktree pointer file — leave it alone
+    path = joinpath(gitdir, "info", "exclude")
+    try
+        old = isfile(path) ? read(path, String) : ""
+        lines = split(old, '\n')
+        missing = [name for name in files if !any(l -> strip(l) == name || strip(l) == "/" * name, lines)]
+        isempty(missing) && return
+        addition = "# SpaceStation agent surface (machine-local; seeded on request)\n" * join(("/" * name for name in missing), "\n") * "\n"
+        mkpath(dirname(path))
+        write(path, (isempty(old) || endswith(old, "\n") ? old : old * "\n") * addition)
+    catch
+    end
+    return
+end
+
+"""
 When a folder workspace is open, refresh its AGENTS.md/CLAUDE.md collab section so any coding agent
-discovers the pluto-collab workflow. **On by default** — the managed block is idempotent and only
-touches its own marked region, so it's safe to (re)write on every open. Opt out with
-`SPACESTATION_AGENTS_MD=0` (also `false`/`no`/`off`) or the `--no-agents-md` flag. The legacy
-`PLUTOSPACE_AGENTS_MD` name remains accepted for compatibility. Only runs for a
-folder workspace (never for a single-notebook or launcher session — there's no project root to seed).
+discovers the pluto-collab workflow.
+
+**Refresh-only by default** (issue #73): a fresh folder is NEVER seeded silently — people who
+don't use AI agents shouldn't find generated files in `git status` just for opening a project.
+Unset, the managed block is only refreshed where it ALREADY exists (a workspace that opted in
+once keeps getting updates). Opt in with `SPACESTATION_AGENTS_MD=1` or `--agents-md` (seeds new
+folders too); opt out entirely with `=0` (also `false`/`no`/`off`) or `--no-agents-md`. The
+legacy `PLUTOSPACE_AGENTS_MD` name remains accepted. Whenever files are written, they are also
+added to `.git/info/exclude` so even opted-in repos keep a clean `git status`. Only runs for a
+folder workspace (never for a single-notebook or launcher session — there's no project root to
+seed).
 """
 function maybe_write_agents_md(session)
-    setting = get(ENV, "SPACESTATION_AGENTS_MD", get(ENV, "PLUTOSPACE_AGENTS_MD", "1"))
+    setting = get(ENV, "SPACESTATION_AGENTS_MD", get(ENV, "PLUTOSPACE_AGENTS_MD", ""))
     lowercase(strip(setting)) in ("0", "false", "no", "off") && return
     dir = session.options.server.workspace_folder
     dir === nothing && return
-    ensure_agents_md(tamepath(dir))
+    dir = tamepath(dir)
+    force = lowercase(strip(setting)) in ("1", "true", "yes", "on")
+    if !force
+        # refresh-only: touch nothing unless this workspace already carries the managed block
+        has_block = any(("AGENTS.md", "CLAUDE.md")) do name
+            path = joinpath(dir, name)
+            isfile(path) || return false
+            content = try read(path, String) catch; "" end
+            occursin(_AGENTS_BEGIN, content) || occursin(_LEGACY_AGENTS_BEGIN, content)
+        end
+        has_block || return
+    end
+    ensure_agents_md(dir)
+    ensure_git_exclude(dir)
     return
 end

--- a/src/cli.jl
+++ b/src/cli.jl
@@ -30,8 +30,11 @@ function main(args)
           spacestation --port <n>         pick a port
           spacestation --autorun          classic Pluto reactivity (default is lazy/collab mode)
           spacestation --no-browser       don't open the browser
-          spacestation --no-agents-md     do NOT seed the workspace's AGENTS.md/CLAUDE.md (seeding
-                                       the managed, idempotent collab block is ON by default)
+          spacestation --agents-md        seed the workspace's AGENTS.md/CLAUDE.md collab block
+                                       (default: only REFRESH the block where it already exists —
+                                       a fresh folder is never touched; --no-agents-md disables
+                                       even that). Seeded files are added to .git/info/exclude,
+                                       so git status stays clean either way.
           spacestation collab <cmd> …     talk to a live session from any terminal (status / run
                                        --stale / output / figure / …); cross-platform, no bash needed.
                                        See: spacestation collab help

--- a/src/collab_cli.jl
+++ b/src/collab_cli.jl
@@ -112,6 +112,7 @@ Commands:
 
 Inside a SpaceStation terminal, SPACESTATION_PORT/SPACESTATION_SECRET target the live session
 automatically. Exit codes: 0 ok · 1 cells errored · 2 no server / bad usage.
+  agents-md                seed ./AGENTS.md + ./CLAUDE.md with the collab block (kept out of git status via .git/info/exclude)
 """
 
 # Parse `--cell <id>` (repeatable), `--json`, `--out <f>`, `--stale` out of a tail arg list.
@@ -142,6 +143,16 @@ working directory (for resolving relative notebook paths). Returns the process e
 """
 function collab_cli_main(args::Vector{String}, cwd::String)::Int
     (isempty(args) || args[1] in ("help", "--help", "-h")) && (print(_COLLAB_HELP); return isempty(args) ? 2 : 0)
+
+    # Explicit, on-demand opt-in for the agent surface files (issue #73: never seeded silently).
+    # Needs no live server — it writes the managed block into ./AGENTS.md + ./CLAUDE.md and adds
+    # both to .git/info/exclude so they stay out of git status.
+    if args[1] == "agents-md"
+        ensure_agents_md(cwd)
+        ensure_git_exclude(cwd)
+        println("seeded AGENTS.md and CLAUDE.md in $(cwd) (git status stays clean: both are in .git/info/exclude)")
+        return 0
+    end
     cmd = args[1]
 
     if cmd == "servers"


### PR DESCRIPTION
Opening a folder workspace no longer touches the folder. Previously every workspace open dropped AGENTS.md and CLAUDE.md into the directory — surprising, git-noisy, and duplicated (#73).

New behavior:

- **Default: refresh-only.** If a workspace already carries the managed collab block (from an earlier version or a deliberate opt-in), the block is kept up to date. A fresh folder is never touched.
- **Opt-in seeding**: `spacestation --agents-md`, `SPACESTATION_AGENTS_MD=1`, or on demand from inside a workspace: `spacestation collab agents-md`.
- **Git stays clean either way**: seeded files are appended to `.git/info/exclude` (machine-local, never committed), so they don't appear in `git status` or diffs.
- `--no-agents-md` still disables even the refresh.

Tested in an isolated repo: fresh open creates nothing; `collab agents-md` creates both files + exclude entries, idempotently; `git status` stays empty after seeding.

Addresses #73

## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/GroupTherapyOrg/SpaceStation.jl", rev="fix/agents-md-opt-in")
julia> using SpaceStation
```
