### PR TITLE
fix: precompile the notebook environment even when the process came up before it existed

### DIFF
--- a/src/evaluation/WorkspaceManager.jl
+++ b/src/evaluation/WorkspaceManager.jl
@@ -199,6 +199,18 @@ function precompile_nbpkg((session, notebook)::SN; io=stdout)::Bool
     not_ready_yet && println(io, "Done. Starting precompilation...")
     Malt.isrunning(workspace.worker) || return false
 
+    # `Pkg.precompile()` below acts on the WORKER's active project, so make sure that is the
+    # notebook's environment before running it. The worker only switches project in
+    # `use_nbpkg_environment`, which runs at process creation (reading `notebook.nbpkg_ctx`
+    # at that moment) and before each cell evaluation. Neither guarantees the switch has
+    # happened here: `Run.jl` starts the process in parallel with `sync_nbpkg`, so a fresh
+    # worker can come up while `nbpkg_ctx` is still `nothing`, and a notebook that gains its
+    # first `import` while already running has a worker that never had a package environment
+    # at all. In both cases precompilation silently ran against the default project — nothing
+    # to do, no output — and the first `import` paid the full compile cost instead (issue #58,
+    # the "Match compiler options" flake). The call is idempotent (`nbpkg_was_active`).
+    use_nbpkg_environment((session, notebook), workspace)
+
     io_writes_channel = Malt.worker_channel(workspace.worker, :(__precomp_io_writes_channel = Channel(10)))
     
     expr = quote

--- a/test/packages/Basic.jl
+++ b/test/packages/Basic.jl
@@ -764,6 +764,47 @@ end
             
             cleanup(🍭, notebook)
         end
+
+        # Issue #58. `Pkg.precompile()` runs inside the notebook process and acts on ITS active
+        # project. The process switches to the notebook environment when it is created — reading
+        # `notebook.nbpkg_ctx` at that moment — and before each cell run. Run.jl deliberately starts
+        # the process in parallel with `sync_nbpkg`, so a fresh notebook's process can come up while
+        # the environment does not exist yet: the sync's precompile step then ran against the default
+        # project, did nothing, said nothing, and the first `import` compiled everything instead. The
+        # race is made deterministic here by starting the process BEFORE the first sync.
+        @testset "Precompiles in the notebook environment when the process came up first" begin
+            let # clear compilation cache
+                Sys.iswindows() && sleep(3) # workaround for https://github.com/JuliaLang/julia/issues/34700
+                isdir(compilation_dir_testA) && rm(compilation_dir_testA; force=true, recursive=true)
+            end
+            @test precomp_entries() == []
+
+            🍭 = autorun_session()
+            # An import for Pluto to recognize, but don't actually run it: running it would
+            # precompile as a side effect and hide what the sync step did or did not do.
+            notebook = Notebook([Cell("false && import PlutoPkgTestA")])
+            @test notebook.nbpkg_ctx === nothing
+            # the process exists before the environment does — with the default project active
+            WorkspaceManager.get_workspace((🍭, notebook))
+            @test !notebook.nbpkg_ctx_instantiated
+
+            update_save_run!(🍭, notebook, notebook.cells)
+            @test notebook.nbpkg_ctx_instantiated
+            env_dir = PkgCompat.env_dir(notebook.nbpkg_ctx)
+            @test WorkspaceManager.eval_fetch_in_workspace((🍭, notebook), :(Base.ACTIVE_PROJECT[])) == env_dir
+
+            # the sync's precompile step produced caches, so the import below has nothing left to compile
+            after_sync = precomp_entries_settled()
+            isempty(after_sync) && @info "No precompile caches after the first sync of a notebook whose process started first.\n" * pkg_state_report(notebook)
+            @test !isempty(after_sync)
+
+            setcode!(notebook.cells[1], "import PlutoPkgTestA")
+            update_save_run!(🍭, notebook, notebook.cells[1])
+            @test noerror(notebook.cells[1])
+            @test precomp_entries_settled() == after_sync
+
+            cleanup(🍭, notebook)
+        end
     end
 
     @testset "Inherit load path" begin


### PR DESCRIPTION
Addresses #58 — the intermittent "Match compiler options" failure. It hit `test (1.10, macOS-latest)` in three of the last four runs on `main`, including the v0.5.3 release commit.

## Cause — a real race, not a test problem

`Pkg.precompile()` runs inside the notebook process and acts on **its** active project. The process only switches to the notebook's environment in `use_nbpkg_environment`, which runs at process creation (reading `notebook.nbpkg_ctx` at that moment) and before each cell evaluation. `Run.jl` deliberately starts the process in parallel with `sync_nbpkg`, so a fresh notebook's process can come up while `nbpkg_ctx` is still `nothing`. The sync's precompile step then runs against the default project: nothing to do, no output — which is exactly the diagnostic dump in the issue (package added, environment instantiated, "Starting precompilation..." printed, no cache written), and the first `import` compiles everything instead.

Any notebook whose process boots before its environment is set up pays that compile cost on first import, so this affects real use, not only the test.

## Fix

`precompile_nbpkg` activates the notebook environment in the process (the existing idempotent call) before evaluating `Pkg.precompile()`.

## Regression test

The race is made deterministic: the test creates the workspace before the first sync, then syncs a notebook that imports `PlutoPkgTestA` and checks that caches exist after the sync and that the import compiles nothing further. Run locally on the Precompilation testset:

| | result |
|---|---|
| previous code | 2 failures: `!(isempty(after_sync))` evaluated with `String[]`, and caches appearing only on import — the CI symptom |
| this branch | 8 of 8 pass |


## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/GroupTherapyOrg/SpaceStation.jl", rev="fix/precompile-env-race")
julia> using SpaceStation
```
