### PR TITLE
fix: give every Windows installer its own Package Code, so a newer .msi upgrades in place

### DIFF
--- a/.github/workflows/Desktop.yml
+++ b/.github/workflows/Desktop.yml
@@ -197,11 +197,15 @@ jobs:
           # cscript, not PowerShell: WindowsInstaller's View.Execute takes an optional Record
           # parameter that neither pwsh 7 nor Windows PowerShell 5.1 will bind (both fail with
           # "Execute,Params"). VBScript is the host Microsoft's own MSI samples use.
-          cscript //nologo stamp_msi.vbs "dist/${{ matrix.built }}" $version icons\spacestation.ico
+          cscript //nologo stamp_msi.vbs "dist/${{ matrix.built }}" $version icons\spacestation.ico | Tee-Object -Variable stampLog
           # PowerShell does NOT fail a step on a native command's exit code, even with
           # ErrorActionPreference=Stop. Without this the stamp could fail and the build would sail on
           # to ship an unstamped .msi — which is exactly what happened.
           if ($LASTEXITCODE -ne 0) { throw "stamp_msi.vbs failed with exit code $LASTEXITCODE" }
+          # ...and a VBScript RUNTIME error (an "Msi API Error" line) exits 0 after printing its
+          # diagnostic, which is how the stamp's own verification silently stopped running for
+          # several releases. The script's last line is the proof that it ran to the end.
+          if (-not ($stampLog -match '^stamped: ')) { throw "stamp_msi.vbs did not run to completion — see its output above" }
 
       - name: Name the release asset
         shell: bash
@@ -282,6 +286,63 @@ jobs:
           Start-Process msiexec -ArgumentList "/x","`"$msi`"","/qn" -Wait
           if (-not $ok) { throw "the installed Windows app failed the #55 regression test" }
           Write-Host "the installed app opened its webview from a writable per-user directory"
+
+      # The regression test for issue #57. An installer users cannot upgrade to is a fix they never
+      # receive. Stamp a higher-versioned copy of the same package and prove a plain `msiexec /i`
+      # REPLACES the installed one rather than landing beside it or bouncing into maintenance mode
+      # on the old product — which is what happened while every build shared one Package Code.
+      - name: Prove the installer upgrades in place (regression test for #57)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        working-directory: desktop
+        run: |
+          $ErrorActionPreference = "Stop"
+          $old = (Resolve-Path "dist/${{ matrix.file }}").Path
+          $new = Join-Path $env:RUNNER_TEMP "SpaceStation-upgrade-test.msi"
+          Copy-Item $old $new -Force
+          cscript //nologo stamp_msi.vbs $new "99.0.0" icons\spacestation.ico | Tee-Object -Variable stampLog
+          if ($LASTEXITCODE -ne 0) { throw "stamp_msi.vbs failed with exit code $LASTEXITCODE" }
+          if (-not ($stampLog -match '^stamped: ')) { throw "stamp_msi.vbs did not run to completion — see its output above" }
+
+          # Read the uninstall registry, NOT Win32_Product: querying that class makes Windows
+          # Installer reconfigure every installed product on the machine, which is slow and actively
+          # harmful. A per-user install registers under HKCU; HKLM is checked too so a per-machine
+          # regression cannot hide.
+          $entries = {
+              @("HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall",
+                "HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall") |
+                  ForEach-Object { Get-ChildItem $_ -ErrorAction SilentlyContinue } |
+                  ForEach-Object { Get-ItemProperty $_.PSPath -ErrorAction SilentlyContinue } |
+                  Where-Object { $_.DisplayName -eq "SpaceStation" }
+          }
+          Start-Process msiexec -ArgumentList "/i","`"$old`"","/qn" -Wait
+          $found = @(& $entries)
+          Write-Host "after installing the release build: $($found.Count) entry/entries, version $(($found | Select-Object -First 1).DisplayVersion)"
+
+          $log = "$env:RUNNER_TEMP\upgrade.log"
+          Start-Process msiexec -ArgumentList "/i","`"$new`"","/qn","/l*v","`"$log`"" -Wait
+          $found = @(& $entries)
+          $after = $found.Count
+          $version = ($found | Select-Object -First 1).DisplayVersion
+          Write-Host "after installing the newer build:  $after entry/entries, version $version"
+
+          $ok = $true
+          if ($after -ne 1) {
+              Write-Host "::error::expected exactly one SpaceStation entry after the upgrade, found $after — the new build installed alongside the old one instead of replacing it."
+              $ok = $false
+          }
+          if ($version -ne "99.0.0") {
+              Write-Host "::error::the installed version is $version, not the 99.0.0 just installed — Windows treated the newer package as the already-installed one and reconfigured it (#57)."
+              $ok = $false
+          }
+          if (-not $ok -and (Test-Path $log)) {
+              Write-Host "--- upgrade.log: FindRelatedProducts / RemoveExistingProducts / reconfigure lines ---"
+              Select-String -Path $log -Pattern "FindRelatedProducts|RemoveExistingProducts|OLDERVERSIONBEINGUPGRADED|reconfigured|Reconfiguration|Return value 3|1603|1402" | ForEach-Object { $_.Line } | Select-Object -First 60
+          }
+          Start-Process msiexec -ArgumentList "/x","`"$new`"","/qn" -Wait
+          Start-Process msiexec -ArgumentList "/x","`"$old`"","/qn" -Wait
+          if (-not $ok) { throw "the Windows installer cannot upgrade in place" }
+          Write-Host "a newer .msi cleanly replaces the installed one"
 
       - name: Sign + notarize (macOS, when credentials exist)
         # NOTE: signing a finished .dmg requires the .app INSIDE to be signed at build time —
@@ -366,11 +427,10 @@ jobs:
           **Windows** — double-click `SpaceStation-win-x64.msi`. If SmartScreen shows *"Windows
           protected your PC"*, click **More info → Run anyway**.
 
-          > **Upgrading from an earlier version? Uninstall it first.** Installing a newer `.msi` over
-          > an existing install currently reconfigures the old version instead of replacing it, so the
-          > update looks like it did nothing. Remove **SpaceStation** from *Settings → Apps → Installed
-          > apps*, then run the new `.msi`. This is a limitation of the installer we generate, tracked
-          > separately; a first-time install is unaffected.
+          > **Upgrading from v0.5.3 or earlier?** Those installers could not be upgraded in place:
+          > run the new `.msi` and, if the installed version does not change, remove **SpaceStation**
+          > from *Settings → Apps → Installed apps* once and install again. From this release on, a
+          > newer `.msi` replaces the installed one directly.
 
           **Linux** — mark the AppImage executable and run it:
 

--- a/desktop/stamp_msi.vbs
+++ b/desktop/stamp_msi.vbs
@@ -21,6 +21,16 @@
 '    FindRelatedProducts / RemoveExistingProducts makes it a proper major upgrade. UpgradeCode is
 '    left alone: it is the stable identity tying releases together.
 '
+' 3. PACKAGE CODE (issue #57). Every build also ships the SAME Package Code - the summary stream's
+'    Revision Number (PID_REVNUMBER, property 9). Windows Installer identifies an .msi FILE by that
+'    GUID and caches the file under %WINDIR%\Installer: a package whose code matches an installed
+'    product's cached package is assumed to BE that file, so installing the newer .msi ran the OLD
+'    cached package - maintenance mode on the old ProductCode, "Windows Installer reconfigured the
+'    product ... version 0.4.7", failing 1603 in the rollback registry. The fresh ProductCode and
+'    the Upgrade table never got a chance to matter. A fresh Package Code per stamp makes each
+'    release a distinct file, which is when FindRelatedProducts / RemoveExistingProducts run and the
+'    major upgrade actually replaces the old install.
+'
 '   cscript //nologo stamp_msi.vbs dist\SpaceStation.msi 0.4.8 icons\spacestation.ico
 '
 ' VBScript, not PowerShell, on purpose. This drives the WindowsInstaller COM automation layer, whose
@@ -33,7 +43,7 @@ Option Explicit
 
 Const msiOpenDatabaseModeTransact = 1
 
-Dim installer, db, msiPath, versionArg, productVersion, productCode, upgradeCode
+Dim installer, db, msiPath, versionArg, productVersion, productCode, packageCode, upgradeCode
 
 If WScript.Arguments.Count < 2 Then
     WScript.Echo "usage: cscript //nologo stamp_msi.vbs <path-to-msi> <version>"
@@ -63,7 +73,8 @@ If upgradeCode = "" Then
     WScript.Echo "this .msi has no UpgradeCode - refusing to stamp an installer with no stable identity"
     WScript.Quit 1
 End If
-productCode = "{" & UCase(Mid(CreateObject("Scriptlet.TypeLib").Guid, 2, 36)) & "}"
+productCode = NewGuid()
+packageCode = NewGuid()
 
 RunSQL "UPDATE `Property` SET `Value`='" & productVersion & "' WHERE `Property`='ProductVersion'"
 RunSQL "UPDATE `Property` SET `Value`='" & productCode & "' WHERE `Property`='ProductCode'"
@@ -118,16 +129,25 @@ RunSQL "INSERT INTO `Property` (`Property`, `Value`) VALUES ('MSIINSTALLPERUSER'
 ' Word Count bit 3 (value 8) in the summary stream declares that elevated privileges are not
 ' required. Without it Windows Installer still treats the package as one that may need machine-wide
 ' access, which is the other half of the HKLM rollback failure above.
-Dim sumInfo, wordCount
+' The summary stream is opened with room for two property updates (the count is the maximum
+' number of properties that may be changed before Persist). Both go in here; the object is
+' released right after, because a live SummaryInformation keeps the .msi open in transact mode
+' and the read-back verification below could not open the file while it was alive - the verify
+' stage had been dying on OpenDatabase for exactly that reason, silently, with its checks unrun.
+Dim sumInfo, wordCount, oldPackageCode
 Set sumInfo = db.SummaryInformation(2)
 wordCount = sumInfo.Property(15)
 If (wordCount And 8) = 0 Then
     sumInfo.Property(15) = wordCount Or 8
-    sumInfo.Persist
     WScript.Echo "summary: set 'elevated privileges not required' (word count " & wordCount & " -> " & (wordCount Or 8) & ")"
 Else
     WScript.Echo "summary: 'elevated privileges not required' already set"
 End If
+oldPackageCode = sumInfo.Property(9)
+sumInfo.Property(9) = packageCode
+sumInfo.Persist
+Set sumInfo = Nothing
+WScript.Echo "summary: PackageCode " & oldPackageCode & " -> " & packageCode
 
 ' ---- Shortcut + Add/Remove Programs icon (issue #63) ----
 ' The packager embeds no icon in the exe, so the Start Menu shortcut and the Programs list show
@@ -153,6 +173,8 @@ If WScript.Arguments.Count >= 3 Then
     iview.Close
     CheckError "Icon table stream insert (" & icoPath & ")"
     On Error GoTo 0
+    Set irec = Nothing
+    Set iview = Nothing
     RunSQL "UPDATE `Shortcut` SET `Icon_`='spacestation.ico'"
     TryRunSQL "DELETE FROM `Property` WHERE `Property`='ARPPRODUCTICON'"
     RunSQL "INSERT INTO `Property` (`Property`, `Value`) VALUES ('ARPPRODUCTICON', 'spacestation.ico')"
@@ -166,20 +188,37 @@ Set installer = Nothing
 ' shipped an .msi still declaring 0.1.0 and still installing into Program Files. So reopen the file
 ' read-only and read the values back. If they did not persist, fail here, where the reason is
 ' visible, rather than three steps later in an install test.
-Dim verifier, vdb, gotVersion, gotAllUsers, gotParent
+Dim verifier, vdb, vsum, gotVersion, gotAllUsers, gotParent, gotIcon, gotProductCode, gotPackageCode
 Set verifier = CreateObject("WindowsInstaller.Installer")
+On Error Resume Next
 Set vdb = verifier.OpenDatabase(msiPath, 0)  ' 0 = read-only
+If Err <> 0 Then
+    WScript.Echo "FAILED: could not reopen " & msiPath & " to verify the stamp: " & Err.Description
+    WScript.Quit 1
+End If
+On Error GoTo 0
 gotVersion = ReadOne(vdb, "SELECT `Value` FROM `Property` WHERE `Property`='ProductVersion'")
+gotProductCode = ReadOne(vdb, "SELECT `Value` FROM `Property` WHERE `Property`='ProductCode'")
 gotAllUsers = ReadOne(vdb, "SELECT `Value` FROM `Property` WHERE `Property`='ALLUSERS'")
 gotParent = ReadOne(vdb, "SELECT `Directory_Parent` FROM `Directory` WHERE `Directory`='INSTALLDIR'")
+gotIcon = ReadOne(vdb, "SELECT `Icon_` FROM `Shortcut`")
+Set vsum = vdb.SummaryInformation(0)
+gotPackageCode = vsum.Property(9)
+Set vsum = Nothing
 Set vdb = Nothing
 Set verifier = Nothing
 
-Dim gotIcon
-gotIcon = ReadOne(vdb, "SELECT `Icon_` FROM `Shortcut`")
-WScript.Echo "verify: ProductVersion=" & gotVersion & " ALLUSERS=[" & gotAllUsers & "] (2 = per-user) INSTALLDIR parent=" & gotParent & " shortcut icon=[" & gotIcon & "]"
+WScript.Echo "verify: ProductVersion=" & gotVersion & " ProductCode=" & gotProductCode & " PackageCode=" & gotPackageCode & " ALLUSERS=[" & gotAllUsers & "] (2 = per-user) INSTALLDIR parent=" & gotParent & " shortcut icon=[" & gotIcon & "]"
 If gotVersion <> productVersion Then
     WScript.Echo "FAILED: ProductVersion did not persist (wanted " & productVersion & ", file says " & gotVersion & ")"
+    WScript.Quit 1
+End If
+If gotProductCode <> productCode Then
+    WScript.Echo "FAILED: ProductCode did not persist (wanted " & productCode & ", file says " & gotProductCode & ")"
+    WScript.Quit 1
+End If
+If gotPackageCode <> packageCode Then
+    WScript.Echo "FAILED: PackageCode did not persist (wanted " & packageCode & ", file says " & gotPackageCode & ") - Windows would keep treating this file as the cached old package (#57)"
     WScript.Quit 1
 End If
 If WScript.Arguments.Count >= 3 And gotIcon <> "spacestation.ico" Then
@@ -190,8 +229,13 @@ If gotParent <> "LocalAppDataFolder" Then
     WScript.Echo "FAILED: INSTALLDIR still parented to " & gotParent & " - the per-user retarget did not persist"
     WScript.Quit 1
 End If
-WScript.Echo "stamped: ProductVersion=" & productVersion & " ProductCode=" & productCode & " UpgradeCode=" & upgradeCode
+WScript.Echo "stamped: ProductVersion=" & productVersion & " ProductCode=" & productCode & " PackageCode=" & packageCode & " UpgradeCode=" & upgradeCode
 WScript.Echo "retargeted: per-user install under LocalAppDataFolder (was per-machine Program Files)"
+
+' A fresh, braced, upper-case GUID - the form every MSI identity column expects.
+Function NewGuid()
+    NewGuid = "{" & UCase(Mid(CreateObject("Scriptlet.TypeLib").Guid, 2, 36)) & "}"
+End Function
 
 Function ReadOne(database, sql)
     Dim view, rec


### PR DESCRIPTION
Addresses #57 — installing a newer `.msi` over an installed one reconfigured the old version and failed with 1603.

## Cause

Every build shipped the same **Package Code** (the summary stream's Revision Number). Windows Installer identifies an `.msi` *file* by that GUID and keeps the installed product's package cached under `%WINDIR%\Installer`: a new file with the same code *is* the cached file as far as it is concerned, so `msiexec` ran the old package — maintenance mode on the old ProductCode, "reconfigured the product … version 0.4.7", 1603 writing rollback scripts. The fresh ProductCode and the Upgrade table never got a chance to matter. This is why none of the per-user/ALLUSERS variations tried in #56 changed anything.

## Also found: the stamp's self-verification had been dead since the icon change

The latest release build's stamp log ends with:

```
summary: set 'elevated privileges not required' (word count 2 -> 10)
stamp_msi.vbs(171, 1) Msi API Error: OpenDatabase,DatabasePath,OpenMode
```

The read-back reopened the database while a `SummaryInformation` object still held it open in transact mode, and a VBScript runtime error exits 0, so the step passed with every check unrun.

## Changes

- `stamp_msi.vbs` writes a fresh Package Code on every stamp, releases the summary and icon objects before the reopen, no longer reads the icon from a released database, and verifies ProductVersion, ProductCode, PackageCode, the per-user retarget and the shortcut icon.
- The CI stamp step requires the script's final `stamped:` line, so a half-run stamp can never ship again.
- The "prove the installer upgrades in place" step is back: install the release build, install a 99.0.0 copy over it, assert exactly one registered SpaceStation at 99.0.0, and print the `FindRelatedProducts` / `RemoveExistingProducts` / reconfigure lines from the msiexec log on failure.
- The release notes' "uninstall first" instruction is narrowed to installs from v0.5.3 or earlier, which genuinely cannot be upgraded in place.

Only the Windows runner can prove this; the Desktop workflow on this PR is the verification.


## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/GroupTherapyOrg/SpaceStation.jl", rev="fix/msi-package-code")
julia> using SpaceStation
```
