### PR TITLE
feat: switch notebook tabs from the keyboard, and open a notebook's environment in a terminal

### DIFF
--- a/frontend/land.css
+++ b/frontend/land.css
@@ -235,6 +235,13 @@ body.resizing #frames iframe {
 .header-menu-item:hover {
     background-color: var(--main-bg-color);
 }
+.header-menu-item:disabled {
+    opacity: 0.5;
+    cursor: default;
+}
+.header-menu-item:disabled:hover {
+    background-color: transparent;
+}
 .header-menu-item.danger {
     color: #d65f5f;
 }

--- a/frontend/land.js
+++ b/frontend/land.js
@@ -729,7 +729,7 @@ const terminal_theme_for = (scheme) => {
           }
 }
 
-const TerminalView = ({ tid, cwd, visible, scheme }) => {
+const TerminalView = ({ tid, cwd, visible, scheme, notebook_env }) => {
     const node_ref = useRef(null)
     const started = useRef(false)
     const fit_ref = useRef(null)
@@ -924,7 +924,10 @@ const TerminalView = ({ tid, cwd, visible, scheme }) => {
             // the server happened to launch. The server falls back to its workspace_folder if omitted.
             const cwd_param = cwd ? `&cwd=${encodeURIComponent(cwd)}` : ""
             const size_param = `&rows=${term.rows}&cols=${term.cols}`
-            socket = new WebSocket(`${proto}://${window.location.host}/terminal?tid=${tid}${cwd_param}${size_param}`)
+            // A notebook-environment terminal (issue #29): the server types `julia --project=<env>`
+            // into the shell it spawns for this tid — only on spawn, so reattaching never repeats it.
+            const env_param = notebook_env ? `&notebook_env=${encodeURIComponent(notebook_env)}` : ""
+            socket = new WebSocket(`${proto}://${window.location.host}/terminal?tid=${tid}${cwd_param}${size_param}${env_param}`)
             socket_ref.current = socket
             socket.binaryType = "arraybuffer"
             // Measure the panel and tell the pty (the server ignores a no-change resize). Called once
@@ -1178,6 +1181,64 @@ const Land = () => {
     const [show_opener, set_show_opener] = useState(false)
     const [menu_open, set_menu_open] = useState(false)
     const menu_ref = useRef(null)
+
+    // ---- Tab switching from the keyboard (issue #29) ----
+    // The conventions every browser, VS Code and iTerm share: ⌘⇧[ / ⌘⇧] and ⌘⌥← / ⌘⌥→ on macOS,
+    // Ctrl+PageUp / Ctrl+PageDown and Ctrl+Tab / Ctrl+Shift+Tab everywhere, ⌘/Ctrl+1…8 for the
+    // Nth tab and ⌘/Ctrl+9 for the last. They cycle the strip as shown: notebooks and files in
+    // order, then the terminal when it is docked as a tab. The handler runs in the CAPTURE phase on
+    // the hub window and, because the notebook frames are same-origin documents that never bubble
+    // keys up here, on each frame's window as it loads (`attach_tab_keys`) — so the chord works with
+    // a cell, a file, the sidebar or the terminal focused. None of it collides with Pluto's own
+    // bindings (cell folding is ⌘⌥[ on macOS and Ctrl+Shift+[ elsewhere) or with xterm.
+    const tab_keys_ref = useRef({ tabs: /** @type {Array<{id: String}>} */ ([]), active: /** @type {String?} */ (null), terminal_tab: false })
+    const handle_tab_keys = useCallback((/** @type {KeyboardEvent} */ e) => {
+        if (e.defaultPrevented || e.isComposing) return
+        const mac = navigator.platform.toUpperCase().includes("MAC")
+        const mod = mac ? e.metaKey && !e.ctrlKey : e.ctrlKey && !e.metaKey
+        let move = 0
+        let jump = -1
+        if (e.ctrlKey && !e.metaKey && !e.altKey && e.key === "Tab") move = e.shiftKey ? -1 : 1
+        else if (e.ctrlKey && !e.metaKey && !e.altKey && !e.shiftKey && (e.key === "PageUp" || e.key === "PageDown")) move = e.key === "PageUp" ? -1 : 1
+        else if (mac && e.metaKey && e.shiftKey && !e.altKey && !e.ctrlKey && (e.code === "BracketLeft" || e.code === "BracketRight")) move = e.code === "BracketLeft" ? -1 : 1
+        else if (mac && e.metaKey && e.altKey && !e.shiftKey && !e.ctrlKey && (e.key === "ArrowLeft" || e.key === "ArrowRight")) move = e.key === "ArrowLeft" ? -1 : 1
+        else if (mod && !e.shiftKey && !e.altKey && /^Digit[1-9]$/.test(e.code)) jump = Number(e.code.slice(5))
+        if (move === 0 && jump < 0) return
+        const { tabs, active, terminal_tab } = tab_keys_ref.current
+        const order = [...tabs.map((t) => t.id), ...(terminal_tab ? ["__terminal__"] : [])]
+        if (order.length === 0) return
+        e.preventDefault()
+        e.stopPropagation()
+        let next
+        if (jump > 0) next = order[jump === 9 ? order.length - 1 : Math.min(jump, order.length) - 1]
+        else {
+            const i = order.indexOf(active ?? "")
+            next = order[(i + move + order.length) % order.length]
+        }
+        if (next != null) set_active(next)
+    }, [])
+    useEffect(() => {
+        window.addEventListener("keydown", handle_tab_keys, true)
+        return () => window.removeEventListener("keydown", handle_tab_keys, true)
+    }, [handle_tab_keys])
+    /** Hook a same-origin frame's window (a notebook tab) into the tab-switching keys. */
+    const attach_tab_keys = useCallback(
+        (/** @type {Window?} */ frame_window) => {
+            try {
+                frame_window?.addEventListener("keydown", handle_tab_keys, true)
+            } catch {
+                // cross-origin (should not happen: ./edit is ours) — the chord just won't work from that frame
+            }
+        },
+        [handle_tab_keys]
+    )
+
+    // ---- "Open the notebook's package environment in a terminal" (issue #29) ----
+    // Answers "I can never remember the invocation": the server composes the exact command for
+    // this Julia and this shell, and types it into a fresh terminal tab, so the line is there to
+    // read, edit and learn. Availability is looked up when the menu opens, for the active notebook.
+    const [notebook_env, set_notebook_env] = useState(/** @type {{id: String, managed: boolean, command?: String}?} */ (null))
+
     // Close the header overflow menu on an outside click or Escape — standard popover behaviour.
     useEffect(() => {
         if (!menu_open) return
@@ -1194,6 +1255,24 @@ const Land = () => {
             document.removeEventListener("keydown", on_key)
         }
     }, [menu_open])
+    tab_keys_ref.current = { tabs, active, terminal_tab: terminal_open && terminal_dock === "tab" }
+
+    const active_notebook_tab = active != null && active !== "__terminal__" && tabs.find((t) => t.id === active && t.kind !== "file")
+    useEffect(() => {
+        if (!menu_open) return
+        if (!active_notebook_tab) {
+            set_notebook_env(null)
+            return
+        }
+        let alive = true
+        get_json(`./api/v1/notebook/env?id=${encodeURIComponent(active_notebook_tab.id)}`)
+            .then((info) => alive && set_notebook_env({ id: active_notebook_tab.id, managed: info?.managed === true, command: info?.command }))
+            .catch(() => alive && set_notebook_env({ id: active_notebook_tab.id, managed: false }))
+        return () => {
+            alive = false
+        }
+    }, [menu_open, active_notebook_tab?.id])
+
     const auto_tabbed = useRef(false)
     // If this tab was spawned by a homebase, it carries the homebase URL in its #fragment — remember it so
     // the "home" button returns there instead of opening a disconnected in-tab launcher.
@@ -1310,7 +1389,7 @@ const Land = () => {
 
     // Terminals are tabs INSIDE the terminal panel (like VS Code). Each is a persistent shell
     // keyed by tid; the list + active terminal are restored on reload. `terminal_seq` numbers them.
-    const [terminals, set_terminals] = useState(/** @type {Array<{tid: String, label: String}>} */ ([]))
+    const [terminals, set_terminals] = useState(/** @type {Array<{tid: String, label: String, notebook_env?: String}>} */ ([]))
     const [active_terminal, set_active_terminal] = useState(/** @type {String?} */ (null))
     const terminals_workspace = useRef(/** @type {String?} */ (null))
     const [terminals_loaded_for, set_terminals_loaded_for] = useState(/** @type {String?} */ (null))
@@ -1402,14 +1481,21 @@ const Land = () => {
         [add_tab]
     )
 
-    const new_terminal = useCallback(() => {
-        if (workspace?.root == null || terminals_workspace.current !== workspace.root) return
-        terminal_seq.current += 1
-        const tid = "term-" + Math.random().toString(36).slice(2, 12)
-        set_terminals((ts) => [...ts, { tid, label: `Terminal ${terminal_seq.current}` }])
-        set_active_terminal(tid)
-        set_terminal_open(true)
-    }, [workspace?.root])
+    /** Open a new terminal tab. `notebook_env` (a notebook id) makes it a notebook-environment
+     *  terminal: the shell starts by activating that notebook's package environment (issue #29). */
+    const new_terminal = useCallback(
+        (/** @type {{label?: String, notebook_env?: String}} */ opts = {}) => {
+            if (workspace?.root == null || terminals_workspace.current !== workspace.root) return
+            terminal_seq.current += 1
+            const tid = "term-" + Math.random().toString(36).slice(2, 12)
+            const entry = { tid, label: opts.label ?? `Terminal ${terminal_seq.current}` }
+            if (opts.notebook_env) entry.notebook_env = opts.notebook_env
+            set_terminals((ts) => [...ts, entry])
+            set_active_terminal(tid)
+            set_terminal_open(true)
+        },
+        [workspace?.root]
+    )
 
     const close_terminal = useCallback((tid) => {
         // Reap the server-side shell (this is a real close, not a detach) — best-effort; the tab is
@@ -1711,7 +1797,7 @@ const Land = () => {
                         <button class="close" title="Close terminal" onClick=${() => close_terminal(t.tid)}>×</button>
                     </div>`
                 )}
-                <button class="new-terminal-tab" title="New terminal" onClick=${new_terminal}>
+                <button class="new-terminal-tab" title="New terminal" onClick=${() => new_terminal()}>
                     <span class="nt-icon">⌨</span><span class="nt-plus">＋</span>
                 </button>
             </div>
@@ -1727,7 +1813,7 @@ const Land = () => {
         <div class="terminal-bodies">
             ${(terminals_workspace.current === workspace?.root ? terminals : []).map(
                 (t) => html`<div key=${t.tid} class="terminal-body ${t.tid === active_terminal ? "active" : ""}">
-                    <${TerminalView} tid=${t.tid} cwd=${workspace?.root} visible=${shown && t.tid === active_terminal} scheme=${terminal_scheme} />
+                    <${TerminalView} tid=${t.tid} cwd=${workspace?.root} visible=${shown && t.tid === active_terminal} scheme=${terminal_scheme} notebook_env=${t.notebook_env} />
                 </div>`
             )}
         </div>
@@ -1810,6 +1896,24 @@ const Land = () => {
                                 <button class="header-button menu-button ${menu_open ? "active" : ""}" title="More actions" aria-haspopup="menu" aria-expanded=${menu_open} onClick=${() => set_menu_open((o) => !o)}><span class="menu-dots"></span></button>
                                 ${menu_open
                                     ? html`<div class="header-menu-popover" role="menu">
+                                          <button
+                                              class="header-menu-item"
+                                              role="menuitem"
+                                              disabled=${!(active_notebook_tab && notebook_env?.id === active_notebook_tab.id && notebook_env.managed)}
+                                              title=${!active_notebook_tab
+                                                  ? "Open a notebook tab first"
+                                                  : notebook_env?.id !== active_notebook_tab.id
+                                                    ? "Checking the notebook's environment…"
+                                                    : notebook_env.managed
+                                                      ? `Opens a terminal running ${notebook_env.command}`
+                                                      : "This notebook manages its own environment (Pkg.activate), so there is nothing to open"}
+                                              onClick=${() => {
+                                                  set_menu_open(false)
+                                                  if (active_notebook_tab) new_terminal({ label: `env: ${basename(active_notebook_tab.path)}`, notebook_env: active_notebook_tab.id })
+                                              }}
+                                          >
+                                              ⌨ Open notebook environment in a terminal
+                                          </button>
                                           <button class="header-menu-item danger" role="menuitem" onClick=${() => {
                                               set_menu_open(false)
                                               shutdown_server()
@@ -1919,7 +2023,12 @@ const Land = () => {
                                           <${FileEditorPane} path=${t.path} visible=${t.id === active} />
                                       </div>`
                                     : // every notebook tab is the stock Pluto editor; iframes stay mounted so switching tabs never loses state
-                                      html`<iframe key=${t.id} src=${`./edit?id=${t.id}`} class=${t.id === active ? "active" : ""}></iframe>`
+                                      html`<iframe
+                                          key=${t.id}
+                                          src=${`./edit?id=${t.id}`}
+                                          class=${t.id === active ? "active" : ""}
+                                          onLoad=${(/** @type {Event} */ e) => attach_tab_keys(/** @type {HTMLIFrameElement} */ (e.target).contentWindow)}
+                                      ></iframe>`
                             )}
                             ${tab_mode
                                 ? html`<div class="pane terminal-area-pane ${active === "__terminal__" ? "active" : ""}">

--- a/src/webserver/CollabAPI.jl
+++ b/src/webserver/CollabAPI.jl
@@ -466,6 +466,24 @@ function register_collab_api!(router, session::ServerSession)
     end
     HTTP.register!(router, "GET", "/api/v1/notebook", serve_api_notebook)
 
+    # A notebook's package environment, for the hub's "open in a terminal" action (issue #29):
+    # whether Pluto manages one, where it is, and the exact command that activates it in a shell
+    # (composed here so the client never has to know which Julia or which shell is in play).
+    function serve_api_notebook_env(request::HTTP.Request)
+        query = HTTP.queryparams(HTTP.URI(request.target))
+        notebook = _api_notebook_from_query(session, query)
+        notebook === nothing && return _api_error(404, "notebook not found — is it open in this server? (pass ?path=/abs/path.jl or ?id=<uuid>)", false)
+        command = notebook_env_command(notebook)
+        env_dir = command === nothing ? nothing : PkgCompat.env_dir(notebook.nbpkg_ctx)
+        body = _json(Pair[
+            "managed" => command !== nothing,
+            "env_dir" => env_dir,
+            "command" => command,
+        ])
+        HTTP.Response(200, ["Content-Type" => "application/json; charset=utf-8"], body * "\n")
+    end
+    HTTP.register!(router, "GET", "/api/v1/notebook/env", serve_api_notebook_env)
+
     # Read ONE cell's FULL output (the status digest caps each cell at 20k; this returns up to 200k
     # so an agent can pull a long result it saw truncated in `status`).
     function serve_api_cell(request::HTTP.Request)

--- a/src/webserver/CollabTerminal.jl
+++ b/src/webserver/CollabTerminal.jl
@@ -199,8 +199,49 @@ function _spawn_workspace_shell(session::ServerSession, dir::String; rows::Int=2
     end
 end
 
+"""
+The shell command that activates a notebook's package environment, exactly as a user would type it
+(issue #29): `julia --project=<env>` with THIS server's Julia — the notebook process runs on the same
+binary, so the Manifest in that environment is only valid for it. `julia` is spelled bare when that
+is what `julia` on PATH resolves to, and as a full path otherwise, so the line always works when
+retyped. Quoted for the shell the terminal actually runs (POSIX sh, PowerShell, or cmd).
+
+Returns `nothing` when the notebook has no Pluto-managed environment (it runs `Pkg.activate` itself,
+or nothing has been loaded yet) — there is nothing to open then.
+"""
+function notebook_env_command(notebook::Notebook)::Union{Nothing,String}
+    ctx = notebook.nbpkg_ctx
+    ctx === nothing && return nothing
+    env_dir = try
+        PkgCompat.env_dir(ctx)
+    catch
+        return nothing
+    end
+    (env_dir === nothing || isempty(env_dir)) && return nothing
+    julia_path = joinpath(Sys.BINDIR, Base.julia_exename())
+    on_path = Sys.which("julia")
+    same = on_path !== nothing && try
+        realpath(on_path) == realpath(julia_path)
+    catch
+        false
+    end
+    julia = same ? "julia" : julia_path
+    if Sys.iswindows()
+        shell = _windows_shell_exe()
+        if endswith(lowercase(shell), "cmd.exe")
+            "\"$(julia)\" --project=\"$(env_dir)\""
+        else
+            # PowerShell: a path with spaces or a full path needs the call operator
+            exe = same ? "julia" : "& '$(replace(julia, "'" => "''"))'"
+            "$(exe) --project='$(replace(env_dir, "'" => "''"))'"
+        end
+    else
+        "$(same ? "julia" : _shquote(julia)) --project=$(_shquote(env_dir))"
+    end
+end
+
 "Get the live terminal for this id, or (re)create one. The pump task forwards PTY output to every attached socket and maintains the scrollback ring."
-function _get_or_create_terminal(session::ServerSession, tid::String; requested_cwd::Union{Nothing,AbstractString}=nothing, rows::Int=24, cols::Int=80)::CollabTerminal
+function _get_or_create_terminal(session::ServerSession, tid::String; requested_cwd::Union{Nothing,AbstractString}=nothing, rows::Int=24, cols::Int=80, run::Union{Nothing,String}=nothing)::CollabTerminal
     lock(COLLAB_TERMINALS_LOCK) do
         target = _resolve_terminal_cwd(session, requested_cwd)
         existing = get(COLLAB_TERMINALS, tid, nothing)
@@ -226,6 +267,17 @@ function _get_or_create_terminal(session::ServerSession, tid::String; requested_
         # delete the new shell's pasted files.
         paste_dir = joinpath(tempdir(), "spacestation-paste-$(_safe_tid(tid))-$(time_ns())")
         t = CollabTerminal(_spawn_workspace_shell(session, target; rows=rows, cols=cols), UInt8[], false, Set{Any}(), ReentrantLock(), @async(nothing), target, paste_dir)
+        # A command to run in the NEW shell, typed ahead as keystrokes: the tty queues it until the
+        # shell reads, so it lands as if the user had typed it — visible in the scrollback, editable
+        # in history, and gone when they exit it — and reattaching (reload, another view) never
+        # repeats it, since only a freshly spawned shell gets here.
+        if run !== nothing
+            try
+                pty_write(t.pty, Vector{UInt8}(codeunits(run * "\n")))
+            catch e
+                @warn "terminal: could not type the initial command" exception = (e, catch_backtrace())
+            end
+        end
         t.pump = @asynclog begin
             for data in t.pty.output
                 # Update scrollback and snapshot the client set UNDER the lock, but do the blocking
@@ -340,9 +392,19 @@ function handle_terminal_websocket(ws, session::ServerSession, query::Dict{Strin
     q_rows = tryparse(Int, get(query, "rows", ""))
     q_cols = tryparse(Int, get(query, "cols", ""))
     sane = q_rows !== nothing && q_cols !== nothing && 1 < q_rows < 1000 && 9 < q_cols < 1000
+    # `notebook_env=<uuid>`: a terminal that starts by activating that notebook's package
+    # environment (issue #29). The server composes the command line — the client never sends
+    # shell text — and it only applies when this tid spawns a new shell.
+    run = nothing
+    nb_id = get(query, "notebook_env", "")
+    if !isempty(nb_id)
+        uuid = tryparse(UUID, nb_id)
+        notebook = uuid === nothing ? nothing : get(session.notebooks, uuid, nothing)
+        run = notebook === nothing ? nothing : notebook_env_command(notebook)
+    end
     t = try
         _get_or_create_terminal(session, tid; requested_cwd=(isempty(cwd) ? nothing : cwd),
-                                rows=(sane ? q_rows : 24), cols=(sane ? q_cols : 80))
+                                rows=(sane ? q_rows : 24), cols=(sane ? q_cols : 80), run=run)
     catch e
         # Spawn failed (e.g. Windows older than 10 1809 has no ConPTY). Say so plainly instead
         # of letting the socket close into the frontend's "reload to reattach" message.


### PR DESCRIPTION
Addresses #29 — the two remaining suggestions from the Discourse feedback, built as the conventions they already are elsewhere.

## Tab switching

The chords every browser, VS Code and iTerm share, so nothing is mac-only:

| | macOS | Windows / Linux |
|---|---|---|
| previous / next tab | Cmd+Shift+[ / Cmd+Shift+], Cmd+Alt+Left / Right | Ctrl+PageUp / Ctrl+PageDown |
| cycle | Ctrl+Tab / Ctrl+Shift+Tab | Ctrl+Tab / Ctrl+Shift+Tab |
| Nth tab, last tab | Cmd+1…8, Cmd+9 | Ctrl+1…8, Ctrl+9 |

They cycle the tab strip as shown — notebooks and files in order, then the terminal when it is docked as a tab. The handler runs in the capture phase on the hub window and on every notebook frame's window as it loads (the frames are same-origin documents whose key events never reach the hub), which is what makes it work with a cell, a file, the sidebar or the terminal focused. Nothing collides with Pluto's own bindings (cell folding is Cmd+Alt+[ on macOS and Ctrl+Shift+[ elsewhere) or with xterm. Cmd+W is deliberately not bound.

## Open notebook environment in a terminal

Lives in the hub's actions menu for the active notebook tab — a per-notebook action without spending toolbar space. The reason given on Discourse is the design: nobody remembers the invocation. So the server composes the exact command for this Julia and this shell (`julia --project=<env>`, as a full path when `julia` on PATH is not this server's binary, quoted for sh, PowerShell or cmd) and types it into a fresh terminal tab as keystrokes, where it is there to read, copy and learn. Only a newly spawned shell gets the line; reattaching after a reload never repeats it. The item is disabled, with the reason, for a notebook that manages its own environment with `Pkg.activate`. A small `GET /api/v1/notebook/env` reports the environment and the command for the menu state.

## Verification

Driven in a WKWebView with real AppKit key events against the live hub with two notebooks open:

- Cmd+Shift+[ and Cmd+Shift+] switch tabs from the hub, from a focused cell inside a notebook frame, and with the terminal focused
- Ctrl+Tab cycles; Cmd+1 and Cmd+2 select the first and second tab
- the menu item is enabled for the active notebook with the composed command in its tooltip; clicking it opens an `env: Markdown.jl` terminal showing the typed command and reaching the `julia>` prompt inside the notebook's environment

`tsc --noEmit` passes; the server change loads and `notebook_env_command` returns `nothing` for a notebook without a managed environment.


## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/GroupTherapyOrg/SpaceStation.jl", rev="feat/notebook-tab-shortcuts")
julia> using SpaceStation
```
