### PR TITLE
fix: a short label for the notebook-environment terminal menu item, with the detail on hover

### DIFF
--- a/frontend/land.css
+++ b/frontend/land.css
@@ -222,6 +222,7 @@ body.resizing #frames iframe {
     gap: 0.5rem;
     width: 100%;
     text-align: left;
+    white-space: nowrap;
     font: inherit;
     font-size: 0.85rem;
     padding: 0.5rem 0.6rem;

--- a/frontend/land.js
+++ b/frontend/land.js
@@ -1906,14 +1906,14 @@ const Land = () => {
                                                   : notebook_env?.id !== active_notebook_tab.id
                                                     ? "Checking the notebook's environment…"
                                                     : notebook_env.managed
-                                                      ? `Opens a terminal running ${notebook_env.command}`
-                                                      : "This notebook manages its own environment (Pkg.activate), so there is nothing to open"}
+                                                      ? `Open a terminal in this notebook's package environment. It runs:\n${notebook_env.command}`
+                                                      : "This notebook has no Pluto-managed environment yet: it has not run, or it activates its own with Pkg.activate"}
                                               onClick=${() => {
                                                   set_menu_open(false)
                                                   if (active_notebook_tab) new_terminal({ label: `env: ${basename(active_notebook_tab.path)}`, notebook_env: active_notebook_tab.id })
                                               }}
                                           >
-                                              ⌨ Open notebook environment in a terminal
+                                              ⌨ Open env in terminal
                                           </button>
                                           <button class="header-menu-item danger" role="menuitem" onClick=${() => {
                                               set_menu_open(false)


### PR DESCRIPTION
Follow-up to #79. The menu item read "Open notebook environment in a terminal", which wrapped onto two lines in the actions menu. It is now "Open env in terminal", the same shape as "Shut down server", and menu items no longer wrap. The hover tooltip carries the explanation and the exact `julia --project` line it will run; the disabled-state tooltip also covers a notebook that has not run yet.

## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/GroupTherapyOrg/SpaceStation.jl", rev="fix/env-menu-label")
julia> using SpaceStation
```
