### PR TITLE
fix: real icons in the workspace actions menu, sized like Pluto's own menus

### DIFF
--- a/frontend/land.css
+++ b/frontend/land.css
@@ -224,14 +224,32 @@ body.resizing #frames iframe {
     text-align: left;
     white-space: nowrap;
     font: inherit;
-    font-size: 0.85rem;
-    padding: 0.5rem 0.6rem;
+    font-size: 0.8rem;
+    padding: 0.4rem 0.6rem;
     border: none;
     background: none;
     color: inherit;
     border-radius: 0.5rem;
     cursor: pointer;
     transition: background-color 0.08s linear, color 0.08s linear;
+}
+/* Ionicons, as everywhere else in the UI (Pluto's cell menu uses the same set): a currentColor mask,
+   so the icon takes the item's text colour — including the danger red. */
+.header-menu-item .menu-icon {
+    flex-shrink: 0;
+    width: 1.1em;
+    height: 1.1em;
+    background-color: currentColor;
+    -webkit-mask: center / contain no-repeat;
+    mask: center / contain no-repeat;
+}
+.header-menu-item .menu-icon.terminal {
+    -webkit-mask-image: url("https://cdn.jsdelivr.net/gh/ionic-team/ionicons@5.5.1/src/svg/terminal-outline.svg");
+    mask-image: url("https://cdn.jsdelivr.net/gh/ionic-team/ionicons@5.5.1/src/svg/terminal-outline.svg");
+}
+.header-menu-item .menu-icon.power {
+    -webkit-mask-image: url("https://cdn.jsdelivr.net/gh/ionic-team/ionicons@5.5.1/src/svg/power-outline.svg");
+    mask-image: url("https://cdn.jsdelivr.net/gh/ionic-team/ionicons@5.5.1/src/svg/power-outline.svg");
 }
 .header-menu-item:hover {
     background-color: var(--main-bg-color);

--- a/frontend/land.js
+++ b/frontend/land.js
@@ -1913,12 +1913,12 @@ const Land = () => {
                                                   if (active_notebook_tab) new_terminal({ label: `env: ${basename(active_notebook_tab.path)}`, notebook_env: active_notebook_tab.id })
                                               }}
                                           >
-                                              ⌨ Open env in terminal
+                                              <span class="menu-icon terminal"></span>Open env in terminal
                                           </button>
                                           <button class="header-menu-item danger" role="menuitem" onClick=${() => {
                                               set_menu_open(false)
                                               shutdown_server()
-                                          }}>⏻ Shut down server</button>
+                                          }}><span class="menu-icon power"></span>Shut down server</button>
                                       </div>`
                                     : null}
                             </div>


### PR DESCRIPTION
Follow-up to #83. The actions menu's two items used text glyphs that rendered as emoji. They now use Ionicons (`terminal-outline`, `power-outline`) as currentColor masks, the same technique as the sidebar's collapse icon, so the power icon takes the danger red. Items are 0.8rem with tighter padding, matching Pluto's cell menu.

## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/GroupTherapyOrg/SpaceStation.jl", rev="fix/menu-icons")
julia> using SpaceStation
```
