### PR TITLE
fix: take the server's access secret from the server itself, never from a stale connection file

### DIFF
--- a/desktop/boot.ts
+++ b/desktop/boot.ts
@@ -33,6 +33,9 @@ export class SpaceStationServer {
     state: BootState = { phase: "idle", detail: "", log: [], url: null, port: null }
     private child: Running | null = null
     private stopping = false
+    /** This server's access secret, once known. Set from the server's own startup line (the
+     *  "Go to http://…?secret=…" it prints) — the one source that cannot belong to another process. */
+    private secret: string | null = null
     onchange: (() => void) | null = null
 
     private set(phase: Phase, detail: string) {
@@ -43,6 +46,13 @@ export class SpaceStationServer {
 
     private log_line(line: string) {
         if (line.trim() === "") return
+        // The server announces its own address, secret included, once it is listening. Take the
+        // secret from there: it is printed by the very process we spawned, so unlike a scan of the
+        // connection-file directory it can never be another run's (see resolve_secret).
+        if (this.secret == null && this.state.port != null) {
+            const m = line.match(new RegExp(`:${this.state.port}/[^\\s]*[?&]secret=([A-Za-z0-9_-]+)`))
+            if (m?.[1]) this.secret = m[1]
+        }
         this.state.log.push(line)
         if (this.state.log.length > LOG_LINES) this.state.log.splice(0, this.state.log.length - LOG_LINES)
         // First-run `Pkg.add`/precompile is the long pole; surface it as its own phase so the
@@ -161,19 +171,71 @@ export class SpaceStationServer {
         return port
     }
 
-    /** SpaceStation writes a connection file per server (port + access secret) exactly so external
-     *  tools can find it — flat JSON in the state dir, keyed `<node>-<port>.json`. */
-    read_secret(port: number): string | null {
+    /** The connection files that claim this port, best first. SpaceStation writes one per server —
+     *  flat JSON in the state dir, keyed `<node>-<port>.json`, carrying the writer's pid and secret —
+     *  and never learns to clean up after a crash, while a Mac's hostname changes with the network
+     *  (VPN, LAN, home), so the same port collects files under several hostnames, each holding a
+     *  dead secret. The old lookup took whichever sorted first; a stale one won and the Launcher
+     *  landed on "Not yet authenticated" (issue #66's thread), and no reinstall could clear it since
+     *  the files live in ~/.local/state. Order now: the file our own child wrote (matching pid), then
+     *  the current hostname's file, then everything else newest first — and the caller verifies. */
+    registry_candidates(port: number, pid: number | null): string[] {
         const home = home_dir()
         const dir = `${Deno.env.get("XDG_STATE_HOME") ?? `${home}/.local/state`}/pluto/servers`
+        // the server tags files with gethostname(), sanitized the same way (CollabAPI._registry_node);
+        // reading the hostname is a permission the packaged app may not hold — then no file gets that rank
+        const node = (() => {
+            try {
+                return Deno.hostname().replace(/[^A-Za-z0-9._-]/g, "_")
+            } catch {
+                return null
+            }
+        })()
+        const found: { secret: string; rank: number; mtime: number }[] = []
         try {
             for (const entry of Deno.readDirSync(dir)) {
                 if (!entry.name.endsWith(`-${port}.json`)) continue
-                const parsed = JSON.parse(Deno.readTextFileSync(`${dir}/${entry.name}`))
-                if (typeof parsed.secret === "string") return parsed.secret
+                try {
+                    const path = `${dir}/${entry.name}`
+                    const parsed = JSON.parse(Deno.readTextFileSync(path))
+                    if (typeof parsed.secret !== "string") continue
+                    const rank = pid != null && parsed.pid === pid ? 0 : node != null && entry.name === `${node}-${port}.json` ? 1 : 2
+                    found.push({ secret: parsed.secret, rank, mtime: Deno.statSync(path).mtime?.getTime() ?? 0 })
+                } catch {
+                    // unreadable or half-written — skip it
+                }
             }
         } catch {
-            // no registry (yet) — the caller falls back to an unauthenticated URL check
+            // no registry (yet)
+        }
+        found.sort((a, b) => a.rank - b.rank || b.mtime - a.mtime)
+        return [...new Set(found.map((f) => f.secret))]
+    }
+
+    /** Does this secret open this server? One authenticated request, so the app never navigates
+     *  the window to a secret it has not seen work. */
+    async secret_works(port: number, secret: string): Promise<boolean> {
+        try {
+            const res = await fetch(`http://127.0.0.1:${port}/api/v1/config?secret=${encodeURIComponent(secret)}`, { signal: AbortSignal.timeout(2000) })
+            await res.body?.cancel()
+            return res.ok
+        } catch {
+            return false
+        }
+    }
+
+    /** The secret to use for `port`: the one the server printed, else the first connection-file
+     *  candidate that actually works. Null when nothing does (the caller then navigates without one,
+     *  which the server may allow when it does not require a secret). */
+    async resolve_secret(port: number): Promise<string | null> {
+        // the announcement is printed right after the server starts answering /ping — give it a beat
+        for (let i = 0; i < 30 && this.secret == null; i++) await new Promise((r) => setTimeout(r, 100))
+        if (this.secret != null && (await this.secret_works(port, this.secret))) return this.secret
+        for (const candidate of this.registry_candidates(port, this.child?.pid ?? null)) {
+            if (await this.secret_works(port, candidate)) {
+                this.secret = candidate
+                return candidate
+            }
         }
         return null
     }
@@ -240,6 +302,7 @@ export class SpaceStationServer {
         const { project, managed } = this.resolve_project()
         const port = this.pick_port()
         this.state.port = port
+        this.secret = null
         // `julia +channel` is juliaup's version selector — it only means something to the shim
         // (the user's ~/.juliaup launcher, or our vendored portable one).
         const use_channel = channel != null && (julia.includes(".juliaup") || julia.includes("juliaup-portable"))
@@ -306,7 +369,8 @@ export class SpaceStationServer {
                 const res = await fetch(`http://127.0.0.1:${port}/ping`, { signal: AbortSignal.timeout(1000) })
                 await res.body?.cancel()
                 if (res.ok) {
-                    const secret = this.read_secret(port)
+                    const secret = await this.resolve_secret(port)
+                    if (secret == null) this.log_line("warning: no working access secret found for this server — the Launcher may ask for one")
                     // ?desktop=1 tells the hub SYNCHRONOUSLY that it's inside the desktop shell
                     // (the server env flag arrives too, but only after an async config fetch)
                     this.state.url = `http://127.0.0.1:${port}/?${secret ? `secret=${secret}&` : ""}desktop=1`
@@ -342,7 +406,7 @@ export class SpaceStationServer {
 
         const port = this.state.port
         if (port != null) {
-            const secret = this.read_secret(port)
+            const secret = this.secret ?? this.registry_candidates(port, child.pid)[0] ?? null
             try {
                 const res = await fetch(`http://127.0.0.1:${port}/api/v1/shutdown${secret == null ? "" : `?secret=${encodeURIComponent(secret)}`}`, {
                     method: "POST",

--- a/desktop/smoke.ts
+++ b/desktop/smoke.ts
@@ -7,6 +7,22 @@
 import { SpaceStationServer } from "./boot.ts"
 
 const server = new SpaceStationServer()
+
+// Regression test for the "Not yet authenticated" Launcher (issue #66's thread): a connection file
+// for the port we are about to use, under another hostname (a Mac's changes with the network), left
+// behind by a crashed or older run, sorting FIRST in the directory and holding a dead secret. The
+// shell used to take it and hand the Launcher the wrong secret. Plant one and insist on getting in.
+const registry_dir = `${Deno.env.get("XDG_STATE_HOME") ?? `${Deno.env.get("HOME") ?? Deno.env.get("USERPROFILE")}/.local/state`}/pluto/servers`
+// A dozen of them: the directory is read in filesystem order (hash order on APFS), so with one
+// stale file the old lookup got lucky often enough to hide the bug; with twelve it almost never does.
+const planned_port = server.pick_port()
+const stale_files = Array.from({ length: 12 }, (_, i) => `${registry_dir}/stale-host-${i}.example-${planned_port}.json`)
+Deno.mkdirSync(registry_dir, { recursive: true })
+for (const f of stale_files) {
+    Deno.writeTextFileSync(f, `{"pid": 1, "host": "127.0.0.1", "port": ${planned_port}, "node": "stale-host", "secret": "stalestale", "workspace": null, "started_at": 0}\n`)
+}
+console.log(`[smoke] planted ${stale_files.length} stale connection files for port ${planned_port} in ${registry_dir}`)
+
 let last_phase = ""
 server.onchange = () => {
     const { phase, detail } = server.state
@@ -38,7 +54,23 @@ const secret = new URL(server.state.url).searchParams.get("secret") ?? ""
 const config = await (await fetch(`http://127.0.0.1:${server.state.port}/api/v1/config?secret=${secret}`)).json()
 console.log(`[smoke] /api/v1/config → desktop: ${config.desktop}, tunneled: ${config.tunneled}`)
 
+const used_stale = secret === "stalestale"
+console.log(`[smoke] stale connection file ignored: ${!used_stale}`)
+
 await server.stop()
-const ok = hub.ok && config.desktop === true
+// the server removes the connection file it wrote on a graceful shutdown
+let own_removed = true
+for (const entry of Deno.readDirSync(registry_dir)) {
+    if (entry.name.endsWith(`-${server.state.port}.json`) && !entry.name.startsWith("stale-host-")) own_removed = false
+}
+console.log(`[smoke] server removed its own connection file on shutdown: ${own_removed}`)
+for (const f of stale_files) {
+    try {
+        Deno.removeSync(f)
+    } catch {
+        // already gone
+    }
+}
+const ok = hub.ok && config.desktop === true && !used_stale && own_removed
 console.log(ok ? "[smoke] PASS" : "[smoke] FAIL")
 Deno.exit(ok ? 0 : 1)

--- a/desktop/spawn.ts
+++ b/desktop/spawn.ts
@@ -56,6 +56,7 @@ export const run_captured = async (cmd: string, args: string[]): Promise<{ succe
 }
 
 export interface Running {
+    pid: number
     status: Promise<{ code: number; success: boolean }>
     kill: (signal: "SIGTERM" | "SIGKILL") => void
 }
@@ -77,6 +78,7 @@ export const spawn_logged = (cmd: string, args: string[], env: Record<string, st
         void pump(child.stdout)
         void pump(child.stderr)
         return {
+            pid: child.pid,
             status: child.status.then((s) => ({ code: s.code, success: s.success })),
             kill: (signal) => child.kill(signal),
         }
@@ -97,5 +99,5 @@ export const spawn_logged = (cmd: string, args: string[], env: Record<string, st
         child.on("close", (c: number | null) => resolve({ code: c ?? 1, success: c === 0 }))
         child.on("error", () => resolve({ code: 1, success: false }))
     })
-    return { status, kill: (signal) => void child.kill(signal) }
+    return { pid: child.pid ?? 0, status, kill: (signal) => void child.kill(signal) }
 }

--- a/src/webserver/WebServer.jl
+++ b/src/webserver/WebServer.jl
@@ -172,8 +172,10 @@ function run!(session::ServerSession)
     # remember the actual port (it may have been auto-chosen) so e.g. the connection file can be rewritten when the workspace changes at runtime
     session.options.server.port = port
 
-    # connection file: lets external tools (e.g. coding agents) discover this server's port and secret
-    write_collab_registry_file(session, port)
+    # connection file: lets external tools (e.g. coding agents) discover this server's port and secret.
+    # Keep the path: the name carries the hostname, which can change while we run (VPN on/off), and
+    # shutdown must remove the file we wrote, not the one today's hostname would name.
+    registry_file = write_collab_registry_file(session, port)
     # agent surface: put `pluto-collab` on PATH next to the app, and (opt-in) seed the workspace's AGENTS.md
     ensure_pluto_collab_installed()
     maybe_write_agents_md(session)
@@ -181,6 +183,10 @@ function run!(session::ServerSession)
     on_shutdown() = @sync begin
         # Triggered by HTTP.jl
         @info("\nClosing SpaceStation... Restart Julia for a fresh session. \n\nHave a nice day! 🎈🏝\n\n")
+        try
+            isfile(registry_file) && rm(registry_file)
+        catch
+        end
         remove_collab_registry_file(port)
         # tear down any SSH remote tunnels so the `ssh -N -L` children don't orphan onto the terminal
         try


### PR DESCRIPTION
Addresses the "Not yet authenticated" Launcher reported in #66's thread.

## Cause

Every server writes a connection file `<hostname>-<port>.json` holding its secret. The shell found the secret by scanning that directory for any file ending in `-<port>.json` and taking the first one the filesystem returned. The file is never removed after a crash or kill, and a Mac's hostname changes with the network (VPN, LAN, home), so one sticky port accumulates files under several hostnames, each holding a past run's dead secret. Which one came first was filesystem order (hash order on APFS), so the same machine could work for weeks and then not, and reinstalling the app never touches `~/.local/state`. The maintainer's own registry directory holds files for port 45200 under six different hostnames going back to June.

## Fix

- **Shell:** the secret comes from the process it spawned. The server prints its own address with the secret once it is listening, and that line is already in the boot log. Failing that, connection files are ranked (the one written by our child's pid, then the current hostname's, then newest first) and every candidate is verified with one authenticated request before the window is pointed at it. Shutdown presents the same secret.
- **Server:** removes the exact file it wrote on graceful shutdown, even if the hostname changed while it ran.

## Verification

The headless smoke (`desktop/smoke.ts`, run on macOS, Windows and Linux by the Desktop workflow) now plants twelve stale connection files for the port it is about to use and requires an authenticated hub afterwards and a clean registry after shutdown.

| shell code | result |
|---|---|
| previous | hub page **HTTP 403** — the reported symptom |
| this branch | HTTP 200, `/api/v1/config` reachable, stale files ignored, own file removed |

Workaround for anyone already stuck on an older build: quit SpaceStation and delete `~/.local/state/pluto/servers/`.


## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/GroupTherapyOrg/SpaceStation.jl", rev="fix/stale-connection-file")
julia> using SpaceStation
```
